### PR TITLE
Added support for package banning

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,6 +112,11 @@ var express = require('express')
   app.put('/deprecate/:engine/:name', passport.authenticate(auth_type, { session: false }), pkg.deprecate_by_engine_and_name);
   app.put('/undeprecate/:engine/:name', passport.authenticate(auth_type, { session: false }), pkg.undeprecate_by_engine_and_name);
 
+// banning
+
+  app.put('/ban/:id', passport.authenticate(auth_type, { session: false }), pkg.ban_by_id);
+  app.put('/unban/:id', passport.authenticate(auth_type, { session: false }), pkg.unban_by_id);
+
 // voting
 
   app.put('/upvote/:id', passport.authenticate(auth_type, { session: false }), pkg.upvote_by_id);

--- a/lib/models.js
+++ b/lib/models.js
@@ -79,6 +79,7 @@ var User = new Schema({
   , num_votes_for_maintained_packages: {type: Number, default: 0 }
   , num_downloads_for_maintained_packages: {type: Number, default: 0 }
   , accepted_terms_of_use: {type: Boolean, default: false }
+  , super_user: {type: Boolean, default: false }
 
 });
 

--- a/lib/models.js
+++ b/lib/models.js
@@ -18,7 +18,10 @@ var Package = new Schema({
   , engine: {type: String, default: 'dynamo'}
 
   , group: {type: String, default: 'global'}
+
+  // status
   , deprecated: {type: Boolean, default: false }
+  , banned:  {type: Boolean, default: false }
 
   // urls
   , site_url: {type: String, default: '' }

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1484,21 +1484,14 @@ function _validate_pkg_deprecation_request(req, pkg_id, callback) {
 		// assert: the user making the change is a current maintainer of this package
 		function(user, pkg, outer_callback) {
 
-            // Only super user or the package maintainer can deprecate a package
-            var user_is_super_user = user.super_user;
 			var user_is_maintainer = false;
-
-            if (!user_is_super_user) {
-                // Check to see if the user is maintainer only if it is not super user
-                for (var i = 0; i < pkg.maintainers.length; i++) {
-                    if ( pkg.maintainers[i].equals( user._id ) ) {
-                        user_is_maintainer = true;
-                        break;					
-                    }
-                }
-            }
-
-			if ( !user_is_super_user && !user_is_maintainer ) {
+			for (var i = 0; i < pkg.maintainers.length; i++) {
+				if ( pkg.maintainers[i].equals( user._id ) ){
+					user_is_maintainer = true;
+					break;					
+				}
+			}
+			if ( !user_is_maintainer ){
 				outer_callback( error.fail('The user sending the new package version, '+ user.username + ', is not a maintainer of the package ' + pkg.name) );
 				return;
 			}

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1484,14 +1484,21 @@ function _validate_pkg_deprecation_request(req, pkg_id, callback) {
 		// assert: the user making the change is a current maintainer of this package
 		function(user, pkg, outer_callback) {
 
+            // Only super user or the package maintainer can deprecate a package
+            var user_is_super_user = user.super_user;
 			var user_is_maintainer = false;
-			for (var i = 0; i < pkg.maintainers.length; i++) {
-				if ( pkg.maintainers[i].equals( user._id ) ){
-					user_is_maintainer = true;
-					break;					
-				}
-			}
-			if ( !user_is_maintainer ){
+
+            if (!user_is_super_user) {
+                // Check to see if the user is maintainer only if it is not super user
+                for (var i = 0; i < pkg.maintainers.length; i++) {
+                    if ( pkg.maintainers[i].equals( user._id ) ) {
+                        user_is_maintainer = true;
+                        break;					
+                    }
+                }
+            }
+
+			if ( !user_is_super_user && !user_is_maintainer ) {
 				outer_callback( error.fail('The user sending the new package version, '+ user.username + ', is not a maintainer of the package ' + pkg.name) );
 				return;
 			}

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1579,7 +1579,6 @@ exports.set_pkg_deprecation = function(req, deprecate_bool, pkg_id, res) {
 
 		if (err) {
 			return res.send(403, err);
-			return;
 		}
 
 		pkg.deprecated = deprecate_bool;
@@ -1617,6 +1616,37 @@ exports.set_pkg_deprecation = function(req, deprecate_bool, pkg_id, res) {
 
 exports.set_pkg_banned = function(req, banned_bool, pkg_id, res) {
 
+	_validate_pkg_ban_request(req, pkg_id, function(err, user, pkg) {
+
+		if (err) {
+            return res.send(403, err);
+		}
+
+        pkg.banned = banned_bool;
+		pkg.markModified('banned');
+		pkg.save(function(err) {
+
+            if (err) {
+                try {
+                    return res.send(500, error.fail('There was a problem updating the package.'));
+                } catch (exception) {
+                    return console.error('Failed to set package banned state');
+                }
+            }
+
+            try {
+                if (banned_bool) {
+                    return res.send(error.success('Package successfully banned.'));
+                } else {
+                    return res.send(error.success('Package successfully unbanned.'));
+                }
+            } catch (exception) {
+                return console.error('Failed to respond to request for package deprecation');
+            }
+
+	    });
+
+	});
 }
 
 /**

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1504,6 +1504,66 @@ function _validate_pkg_deprecation_request(req, pkg_id, callback) {
 
 
 /**
+ * Validate whether the user can ban this pkg
+ *
+ * @param {Object} The request object
+ * @param {bool} The new banned state
+ * @param {ObjectId} The id of the pkg
+ * @param {Function} Callback to execute after inserting. Callback is an error object
+ * @api private
+ */
+
+function _validate_pkg_ban_request(req, pkg_id, callback) {
+
+	if ( !req || !req.user ) {
+		callback( error.fail('There must be a user associated with a package update.') );
+		return;
+	}
+
+	// waterfall runs functions in series, passing results to the next function
+	// if any function returns error object, the whole thing terminates
+	async.waterfall([ 
+		
+		// assert: the user making the change exists in db
+		function(outer_callback) {
+
+			users.get_user_by_name(req.user.username, function(err, user) {
+				if (err || !user) {
+					outer_callback(error.fail('Failed to look up the username'));
+					return;
+				}
+
+				outer_callback(null, user); // user var is passed to the next func
+			});
+		},
+		// assert: the package does exist in db
+		function(user, outer_callback) {
+
+			PackageModel.findById(pkg_id, function(err, pkg) {
+				if (err || !pkg) {
+					outer_callback( error.fail('The package does not exist in the database.'));
+					return;
+				}
+				outer_callback(null, user, pkg);
+			});
+
+		},
+		// assert: the user banning/unbanning the package must be a super user
+		function(user, pkg, outer_callback) {
+
+			if ( !user.super_user ){
+				outer_callback( error.fail('In order to ban the package '+ pkg.name + ', user ' + user.username + ' must be a super user.') );
+				return;
+			}
+			outer_callback(null, user, pkg);
+		}
+
+	], callback);
+
+};
+
+
+/**
  * Set whether a package is deprecated or not
  *
  * @param {Object} The request object

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1515,50 +1515,50 @@ function _validate_pkg_deprecation_request(req, pkg_id, callback) {
 
 function _validate_pkg_ban_request(req, pkg_id, callback) {
 
-	if ( !req || !req.user ) {
-		callback( error.fail('There must be a user associated with a package update.') );
-		return;
-	}
+    if ( !req || !req.user ) {
+        callback( error.fail('There must be a user associated with a package update.') );
+        return;
+    }
 
-	// waterfall runs functions in series, passing results to the next function
-	// if any function returns error object, the whole thing terminates
-	async.waterfall([ 
-		
-		// assert: the user making the change exists in db
-		function(outer_callback) {
+    // waterfall runs functions in series, passing results to the next function
+    // if any function returns error object, the whole thing terminates
+    async.waterfall([ 
+        
+        // assert: the user making the change exists in db
+        function(outer_callback) {
 
-			users.get_user_by_name(req.user.username, function(err, user) {
-				if (err || !user) {
-					outer_callback(error.fail('Failed to look up the username'));
-					return;
-				}
+            users.get_user_by_name(req.user.username, function(err, user) {
+                if (err || !user) {
+                    outer_callback(error.fail('Failed to look up the username'));
+                    return;
+                }
 
-				outer_callback(null, user); // user var is passed to the next func
-			});
-		},
-		// assert: the package does exist in db
-		function(user, outer_callback) {
+                outer_callback(null, user); // user var is passed to the next func
+            });
+        },
+        // assert: the package does exist in db
+        function(user, outer_callback) {
 
-			PackageModel.findById(pkg_id, function(err, pkg) {
-				if (err || !pkg) {
-					outer_callback( error.fail('The package does not exist in the database.'));
-					return;
-				}
-				outer_callback(null, user, pkg);
-			});
+            PackageModel.findById(pkg_id, function(err, pkg) {
+                if (err || !pkg) {
+                    outer_callback( error.fail('The package does not exist in the database.'));
+                    return;
+                }
+                outer_callback(null, user, pkg);
+            });
 
-		},
-		// assert: the user banning/unbanning the package must be a super user
-		function(user, pkg, outer_callback) {
+        },
+        // assert: the user banning/unbanning the package must be a super user
+        function(user, pkg, outer_callback) {
 
-			if ( !user.super_user ){
-				outer_callback( error.fail('In order to ban the package '+ pkg.name + ', user ' + user.username + ' must be a super user.') );
-				return;
-			}
-			outer_callback(null, user, pkg);
-		}
+            if ( !user.super_user ){
+                outer_callback( error.fail('In order to ban the package '+ pkg.name + ', user ' + user.username + ' must be a super user.') );
+                return;
+            }
+            outer_callback(null, user, pkg);
+        }
 
-	], callback);
+    ], callback);
 
 };
 
@@ -1616,15 +1616,15 @@ exports.set_pkg_deprecation = function(req, deprecate_bool, pkg_id, res) {
 
 exports.set_pkg_banned = function(req, banned_bool, pkg_id, res) {
 
-	_validate_pkg_ban_request(req, pkg_id, function(err, user, pkg) {
+    _validate_pkg_ban_request(req, pkg_id, function(err, user, pkg) {
 
-		if (err) {
+        if (err) {
             return res.send(403, err);
-		}
+        }
 
         pkg.banned = banned_bool;
-		pkg.markModified('banned');
-		pkg.save(function(err) {
+        pkg.markModified('banned');
+        pkg.save(function(err) {
 
             if (err) {
                 try {
@@ -1644,9 +1644,9 @@ exports.set_pkg_banned = function(req, banned_bool, pkg_id, res) {
                 return console.error('Failed to respond to request for package deprecation');
             }
 
-	    });
+        });
 
-	});
+    });
 }
 
 /**

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1553,6 +1553,20 @@ exports.set_pkg_deprecation = function(req, deprecate_bool, pkg_id, res) {
 };
 
 /**
+ * Set whether a package is banned or not
+ *
+ * @param {Object} The request object
+ * @param {bool} The new banned state
+ * @param {ObjectId} The id of the pkg
+ * @param {Function} Callback to execute after inserting. The arguments are an error object (null if successful) and the banned pkg.
+ * @api private
+ */
+
+exports.set_pkg_banned = function(req, banned_bool, pkg_id, res) {
+
+}
+
+/**
  * Obtain a package by engine and name
  *
  * @param {string} The name of the package
@@ -1565,7 +1579,7 @@ exports.by_engine_and_name = function(engine, name, callback) {
 
   	PackageModel
   	.findOne( {engine: engine, name: name} )
-	  .populate('maintainers', 'username')
+	.populate('maintainers', 'username')
   	.populate('versions.direct_dependency_ids', 'name')
   	.populate('versions.full_dependency_ids', 'name')
   	.populate('used_by', 'name')
@@ -1585,7 +1599,7 @@ exports.by_id = function(id, callback) {
 
   	PackageModel
   	.findById(id)
-	  .populate('maintainers', 'username')
+	.populate('maintainers', 'username')
   	.populate('versions.direct_dependency_ids', 'name')
   	.populate('versions.full_dependency_ids', 'name')
   	.populate('used_by', 'name')

--- a/routes/package.js
+++ b/routes/package.js
@@ -45,6 +45,34 @@ exports.undeprecate_by_id = function(req, res) {
 };
 
 /**
+ * Ban a package
+ *
+ * @param {Object} HTTP request 
+ * @param {Object} HTTP response
+ * @api public
+ */
+exports.ban_by_id = function(req, res) {
+
+  var pkg_id = req.params.id;
+  packages.set_pkg_banned( req, true, pkg_id, res );
+
+};
+
+/**
+ * Unban a package
+ *
+ * @param {Object} HTTP request 
+ * @param {Object} HTTP response
+ * @api public
+ */
+exports.unban_by_id = function(req, res) {
+
+  var pkg_id = req.params.id;
+  packages.set_pkg_banned( req, false, pkg_id, res );
+
+};
+
+/**
  * Deprecate a package by engine and name
  *
  * @param {Object} HTTP request 


### PR DESCRIPTION
### Purpose

This pull request adds REST APIs for for banning/unbanning a package. It is meant to address the following internally tracked task:

- [MAGN-7117](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7117) As Dynamo team members, we should be given the ability to remove a published package, so that we can respond quickly if any package is found to be offensive.

Main changes include:

1. New REST end-points `/ban` and `/unban` are added (require authenticated user)
2. New field `banned` is added to `Package` schema to denote a banned status of a package.
3. New field `super_user` is added to `User` schema to denote a super user (only super users can mark a package as banned or unbanned).
4. New exported function `set_pkg_banned` is added to perform actual database update.
5. New helper function `_validate_pkg_ban_request` is added to validate each package ban request.

I have made [another pull request](https://github.com/DynamoDS/GRegClientNET/pull/3) that adds client-side APIs to work with these new REST APIs.

Pending work:

- `Package.banned` field is not currently used to filter the search result, need @pboyer's help here.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

Hi @pboyer, please help to take a look. The reason `deprecated` field isn't enough is because the maintainer can always restore its value to `false`. Also, `deprecated` field carries a different meaning as compared to `banned`. Having a different field `banned` will not only make the intent clearer, but also limit what type of user can alter its value.
