### PR TITLE
Callback inside upload callback.

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -823,13 +823,12 @@ function _validate_new_pkg(req, pkg_data, callback) {
 			  }
 
 			  try{
-                  storage.upload(req, pkg_data, exports.guid());
+                    storage.upload(req, pkg_data, exports.guid(), function(){
+                      outer_callback(null, users);
+                });
               }catch(err){
                   outer_callback(err);
               }
-              
-              outer_callback(null, users);
-
 			});
 		}
 	// closing waterfall

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -27,7 +27,7 @@ var mockBucket = './test/mock_bucket/';
  */
 exports.upload =    (process.env.NODE_ENV == "production" || process.env.NODE_ENV == "development" )? uploadToS3 : saveToDisk;
 
-function uploadToS3( req, pkg_data, guid){
+function uploadToS3( req, pkg_data, guid, callback){
 
         var bodyStream = fs.createReadStream( req.files.pkg.path );
 
@@ -52,14 +52,14 @@ function uploadToS3( req, pkg_data, guid){
 
                 // get the url
                 pkg_data.url = "https://s3.amazonaws.com/" + S3_BUCKET_NAME + "/" + objectName;
-
+                callback();
         });
         } catch (e) {
             throw e;
         }
 };
 
-function saveToDisk(req, pkg_data, guid){
+function saveToDisk(req, pkg_data, guid, callback){
     
     var objectName = guid + req.files.pkg.name;
     
@@ -71,5 +71,6 @@ function saveToDisk(req, pkg_data, guid){
     
     var resolved = path.resolve("../test/mock_bucket", "./" + objectName);
     pkg_data.url = resolved;
+    callback();
 };
     


### PR DESCRIPTION
This PR fixes an issue with the package manager where the URL of an uploaded package was not being set. This was due to the outer callback from the waterfall being called before the upload method could complete, setting the url. In this PR, we extend the upload methods to take a callback, in which we call the outer callback. This ensures that the url is set for the package.

FYI @pboyer 