### PR TITLE
Add Additonal Fields to Db

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,16 +5,16 @@
 			"name": "Launch",
 			"type": "node",
 			"request": "launch",
-			"program": "app.js",
+			"program": "${workspaceRoot}/app.js",
 			"stopOnEntry": false,
 			"args": [],
-			"cwd": ".",
+			"cwd": "${workspaceRoot}/.",
 			"runtimeExecutable": null,
 			"runtimeArgs": [
 				"--nolazy"
 			],
 			"env": {
-				"NODE_ENV": "development"
+				"NODE_ENV": "test"
 			},
 			"externalConsole": false,
 			"sourceMaps": false,
@@ -34,7 +34,7 @@
             "args": [],
             "cwd": ".",
             "runtimeExecutable": null,
-            "env": { "NODE_ENV": "development"}
+            "env": { "NODE_ENV": "test"}
         }
 	]
 }

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -904,24 +904,26 @@ function _save_new_pkg (pkg_data, req, callback) {
 
 	var pkg = new PackageModel({
 
-		name: pkg_data.name
-	  , description: pkg_data.description
-	  , keywords: pkg_data.keywords
-	  , maintainers: [pkg_data.user_id]
-	  , site_url: pkg_data.site_url ? pkg_data.site_url : ""
-		, repository_url: pkg_data.repository_url ? pkg_data.repository_url : ""
-		, group: pkg_data.group
-	  , engine: pkg_data.engine
-		, versions: [{
-		    version: pkg_data.version
-		  , engine_version: pkg_data.engine_version
-		  , engine_metadata: pkg_data.engine_metadata
-	    , direct_dependency_ids: pkg_data.direct_dependency_ids
-	    , direct_dependency_versions: pkg_data.direct_dependency_versions
-		  , license: pkg_data.license
-		  , contents: pkg_data.contents
-		  , url: pkg_data.url
-		}]
+        name: pkg_data.name
+        , description: pkg_data.description
+        , keywords: pkg_data.keywords
+        , maintainers: [pkg_data.user_id]
+        , site_url: pkg_data.site_url ? pkg_data.site_url : ""
+        , repository_url: pkg_data.repository_url ? pkg_data.repository_url : ""
+        , group: pkg_data.group
+        , engine: pkg_data.engine
+        , versions: [{
+            version: pkg_data.version
+            , engine_version: pkg_data.engine_version
+            , engine_metadata: pkg_data.engine_metadata
+            , direct_dependency_ids: pkg_data.direct_dependency_ids
+            , direct_dependency_versions: pkg_data.direct_dependency_versions
+            , license: pkg_data.license
+            , contents: pkg_data.contents
+            , url: pkg_data.url
+            , contains_binaries: pkg_data.contains_binaries
+            , node_libraries: pkg_data.node_libraries
+        }]
 
 	});
 
@@ -1146,14 +1148,16 @@ exports.increasing_pkg_version = function(v1, v2) {
 function _save_new_pkg_version(pkg_data, req, callback) {
 
 	var pkg_v = { 
-			version: pkg_data.version
-		, engine_version: pkg_data.engine_version
-	  , engine_metadata: pkg_data.engine_metadata
-    , direct_dependency_ids: pkg_data.direct_dependency_ids
-    , direct_dependency_versions: pkg_data.direct_dependency_versions
-	  , license: pkg_data.license
-	  , contents: pkg_data.contents
-	  , url: pkg_data.url
+        version: pkg_data.version
+        , engine_version: pkg_data.engine_version
+        , engine_metadata: pkg_data.engine_metadata
+        , direct_dependency_ids: pkg_data.direct_dependency_ids
+        , direct_dependency_versions: pkg_data.direct_dependency_versions
+        , license: pkg_data.license
+        , contents: pkg_data.contents
+        , url: pkg_data.url
+        , contains_binaries: pkg_data.contains_binaries
+        , node_libraries: pkg_data.node_libraries
 	};
 
 	async.waterfall([ 

--- a/models/package.js
+++ b/models/package.js
@@ -56,6 +56,8 @@ var Package = new Schema({
     , contents: {type: String, default:''}
     , url: {type: String, default: 'none'}
     , url_with_deps: {type: String, default: ''} 
+    , node_libraries: [{type: String, default:''}]
+    , contains_binaries: {type: Boolean, default: false}
   }]
 
   // white listing


### PR DESCRIPTION
This PR adds two additional fields to a package version in the db, `contains_binaries` and `node_libraries`. These values were already being conveyed to Greg in package upload requests, but they were not being stored. As such, it was impossible for us in any Greg client to figure out what assemblies were in white-listed packages without downloading the packages first, and reading their `pkg.json` files. With this addition, we can now simply call the `/whitelist` API, and the returned package data includes version information complete with node library assembly names.

In addition, this PR makes small modifications to `launch.json` to allow running in `test` mode when pressing F5 in Visual Studio code. And, it fixes indentation in code showing package data to increase legibility.

PTAL @mjkkirschner 