### PR TITLE
Fix download counter.

### DIFF
--- a/routes/package.js
+++ b/routes/package.js
@@ -317,12 +317,11 @@ exports.download_vers = function(req, res) {
                     var pathParse = path.parse(pkgUrl);
                     return res.sendfile( pathParse.base, {root: path.resolve('test/mock_bucket/') } );
                 }else{
+                    pkg.downloads = pkg.downloads + 1;
+                    pkg.markModified('downloads');
+                    pkg.save();
                     return res.redirect( pkg.versions[i].url )
                 }
-                
-                pkg.downloads = pkg.downloads + 1;
-                pkg.markModified('downloads');
-                return pkg.save();
         } catch (exception) {
           return res.send(500, error.fail('Failed to redirect' ));
         }


### PR DESCRIPTION
During the introduction of code to allow local package testing, the code for incrementing the download total on a package was made unreachable. This PR fixes that.