### PR TITLE
Add route & functionality to handle user package deletion requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,6 +64,7 @@ var express = require('express')
 
   app.get('/package/:id', pkg.by_id );
   app.get('/package/:engine/:name', pkg.by_engine_and_name );
+  app.get('/package/:name', pkg.by_package_name );
 
 // download pkg contents
 

--- a/app.js
+++ b/app.js
@@ -64,7 +64,6 @@ var express = require('express')
 
   app.get('/package/:id', pkg.by_id );
   app.get('/package/:engine/:name', pkg.by_engine_and_name );
-  app.get('/package_name/:name', pkg.by_package_name );
 
 // download pkg contents
 
@@ -75,6 +74,7 @@ var express = require('express')
 
   app.get('/packages', pkg.all );
   app.get('/packages/:engine', pkg.by_engine );
+  app.get('/package_name/:name', pkg.by_package_name );
 
 // stats
 

--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ var express = require('express')
   , stats_update = require('./lib/stats_update')
   , package_deletion = require('./lib/package_deletion')
   , request = require('request')
-  , secrets = require("./secrets")
+  , secrets = require("./lib/secrets")
   , gdpr = require('./lib/gdpr');
 
 ////////////////////////

--- a/app.js
+++ b/app.js
@@ -156,8 +156,12 @@ app.post('/gdprDeleteRequest', gdpr.handleGDPRRRequest);
 // Pkg Deletion Requests
 ////////////////////////
 setInterval(function(){
-  package_deletion.remove_packages(function(data){ console.log(data); });
-}, 1000 * 60 * 60 * 24 * 7 ); // once a week
+  package_deletion.remove_packages(function(data) { 
+    // TODO - this response should be sent to slack notification channel
+    console.log(data); 
+  });
+}, 1000 *60 * 60 * 24 * 7 ); // once a week
+
 
 ////////////////////////
 // Server

--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ var express = require('express')
     , error = require('./lib/error')
   , stats_update = require('./lib/stats_update')
   , package_deletion = require('./lib/package_deletion')
+  , request = require('request')
   , gdpr = require('./lib/gdpr');
 
 ////////////////////////
@@ -157,8 +158,19 @@ app.post('/gdprDeleteRequest', gdpr.handleGDPRRRequest);
 ////////////////////////
 setInterval(function(){
   package_deletion.remove_packages(function(data) { 
-    // TODO - this response should be sent to slack notification channel
-    console.log(data); 
+    // Data returned from callback will be sent to Slack #dynamo-notify
+    var options = {
+      uri: 'Webhook Url',
+      method: 'POST',
+      json: {
+        "text" : data.toString()
+      }
+    };
+    
+    request(options, function (error, response, body) {
+      if(error) { console.log(error); }
+      else { console.log(body) }
+    });
   });
 }, 1000 *60 * 60 * 24 * 7 ); // once a week
 

--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ var express = require('express')
     , basic_auth = require('./lib/basic_auth')
     , error = require('./lib/error')
   , stats_update = require('./lib/stats_update')
+  , package_deletion = require('./lib/package_deletion')
   , gdpr = require('./lib/gdpr');
 
 ////////////////////////
@@ -150,6 +151,13 @@ var express = require('express')
 // GDPR
 ////////////////////////
 app.post('/gdprDeleteRequest', gdpr.handleGDPRRRequest);
+
+////////////////////////
+// Pkg Deletion Requests
+////////////////////////
+setInterval(function(){
+  package_deletion.remove_packages(function(data){ console.log(data); });
+}, 1000 * 60 * 60 * 24 * 7 ); // once a week
 
 ////////////////////////
 // Server

--- a/app.js
+++ b/app.js
@@ -64,7 +64,7 @@ var express = require('express')
 
   app.get('/package/:id', pkg.by_id );
   app.get('/package/:engine/:name', pkg.by_engine_and_name );
-  app.get('/package/:name', pkg.by_package_name );
+  app.get('/package_name/:name', pkg.by_package_name );
 
 // download pkg contents
 

--- a/app.js
+++ b/app.js
@@ -75,7 +75,7 @@ var express = require('express')
 
   app.get('/packages', pkg.all );
   app.get('/packages/:engine', pkg.by_engine );
-  app.get('/package_name/:name', pkg.by_package_name );
+  app.get('/package_id/:name', pkg.by_package_name );
 
 // stats
 

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -125,8 +125,8 @@ function removePackageByKey(params, s3, callback) {
             }
         }
 
-        return callback('New package deletion request on ' + new Date().toDateString());
-
+        let date = new Date();
+        return callback('A package manager deletion request was executed on ' + date.toDateString() + ' at ' + date.toISOString());
     });
 }
 

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -7,7 +7,9 @@ let PackageModel = require('../models/package').PackageModel,
 /**
  * Parses a local JSON file containing ObjectIds
  * for packages that will attempt to be deleted.
-**/
+ * 
+ * callback: function that takes a string to be displayed on the notifications slack channel
+ */
 exports.remove_packages = function(callback){
 
     console.log('Starting package deletion scan...')
@@ -48,6 +50,13 @@ exports.remove_packages = function(callback){
     });
 };
 
+/**
+ * Remove a package by providing the following
+ * 
+ * @param params: S3 'Bucket' and 'Key' object
+ * @param s3: reference to S3 credentials
+ * @param callback: function that takes a string to be displayed on the notifications slack channel
+ */
 function removePackageByKey(params, s3, callback) {
     s3.getObject(params, function(error, data) {
         if (error) { 
@@ -100,8 +109,11 @@ function removePackageByKey(params, s3, callback) {
                                             return callback(error)
                                         }
                                         else {
-                                            // TODO move JSON file by key to 'Executed-Deletions`
-                                            // TODO delete JSON file from 'New-Deletions'
+                                            // At this point all DB work is complete without errors
+                                            // Attempt to copy JSON file in S3 from 'New-Deletions' to 'Executed-Deletions' dir
+                                            moveS3File(params, s3, callback);
+                                            
+                                            // Complete
                                             return callback(package.name + ' authored by ' + user.username + ' was successfully deleted')
                                         }
                                     });
@@ -113,7 +125,48 @@ function removePackageByKey(params, s3, callback) {
             }
         }
 
-        return callback('New package deletion request at ' + new Date().toString());
+        return callback('New package deletion request on ' + new Date().toUTCString());
 
+    });
+}
+
+/**
+ * Copy a JSON file on S3 'New-Deletions' to 'Executed-Deletions'
+ * And delete the original source file if copy is sucessful
+ * 
+ * @param params: S3 'Bucket' and 'Key' object
+ * @param s3: reference to S3 credentials
+ * @param callback: function that takes a string to be displayed on the notifications slack channel
+ */
+function moveS3File(params, s3, callback) {
+    let updateParams = {
+        Bucket: params.Bucket, 
+        CopySource: '/Executed-Deletions/' + new Date().toUTCString(), 
+        Key: params.Key
+    }
+
+    s3.copyObject(updateParams, function(error, data) {
+        if(err) {
+            callback(error);
+        }
+        else {
+            // If copy is successful, delete source file from 'New-Deletions'
+            deleteS3File(params, s3, callback)
+        }
+    });
+}
+
+/**
+ * Delete a file on S3
+ * 
+ * @param params: S3 'Bucket' and 'Key' object
+ * @param s3: reference to S3 credentials
+ * @param callback: function that takes a string to be displayed on the notifications slack channel
+ */
+function deleteS3File(params, s3, callback) {
+    s3.deleteObject(params, function(error, data) {
+        if(err) {
+           callback(error);
+        }
     });
 }

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -31,7 +31,7 @@ exports.remove_packages = function(callback){
             return callback(error);
         }
         else if(data.Contents.length === 0) {
-            return callback('Found 0 matching deletion files in S3 package-manager-deletion-requests/New-Deletions/');
+            return callback('No deletion files found in S3 package-manager-deletion-requests/New-Deletions/');
         }
         else { 
             let keys = data.Contents;

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -1,7 +1,7 @@
 let PackageModel = require('../models/package').PackageModel,
     UserModel = require('../models/user').UserModel,
     mongoose = require('mongoose'),
-    _ = require('underscore'),
+    amazonS3 = require('awssum-amazon-s3')
     fs = require('fs');
 
 /**
@@ -12,92 +12,102 @@ exports.remove_packages = function(callback){
 
     console.log('Starting package deletion scan...')
 
-    // TODO should point to current directory structure (ssl folder where S3 JSON file is copied)
-    let packageIdJson = 'C:/Users/alfarok/Documents/GReg_alfarok/packagesToDelete.json';
+    let s3 = new amazonS3.S3({
+        'accessKeyId'     : process.env.AWSAccessKeyId,
+        'secretAccessKey' : process.env.AWSSecretKey,
+        'region'          : amazonS3.US_EAST_1
+    });
 
-    // Load S3 JSON from local disk (requires another script that copies JSON from S3 to local machine)
-    fs.readFile(packageIdJson, 'utf8', function (error, data) {
-        
-        if (error) {
-            console.log('Unable to read JSON file');
+    // Load S3 data
+    let params = {
+        BucketName: 'package-manager-deletion-requests', 
+        ObjectName: 'New-Deletion/packagesToDelete.json'
+    };
+
+    s3.GetObject(params, function(error, data) {
+        if (error) { 
+            console.log(error, error.stack);
             return callback(error);
         }
-        else if (!data) {
-            return callback("JSON file is null");
-        }
         else {
-            let deletionObjects = JSON.parse(data);
+            let fileContents = data.Body.toString();
+            var deletionObjects = JSON.parse(fileContents);
+            
+            if(!deletionObjects) {
+                return callback("JSON file is null");
+            }
+            else {
+                console.log(deletionObjects.length.toString() + ' packages to be deleted');
 
-            console.log(deletionObjects.length.toString() + ' packages to be deleted');
+                // For each package id loaded from the JSON file
+                deletionObjects.forEach(deletionObject => {
 
-            // For each package id loaded from the JSON file
-            deletionObjects.forEach(deletionObject => {
+                    let packageId = deletionObject.package_id;
+                    // An array of maintainers
+                    let maintainers = deletionObject.maintainers;
 
-                let packageId = deletionObject.package_id;
-                // An array of maintainers
-                let maintainers = deletionObject.maintainers;
-
-                // Find package by id
-                PackageModel.findById(new mongoose.Types.ObjectId(packageId), (error, package) => {
-                    if(error) {
-                        console.log('Unable to find package with matching ObjectId: ' + packageId);
-                        return callback(error);
-                    }
-                    else if(!package) {
-                        return callback('Query returned a null package for ObjectId: ' + packageId);
-                    }
-                    else {
-                        console.log('Found package with matching ObjectId: ' + package._id + ' - ' + package.name);
-                        
-                        // Remove Package
-                        package.remove((error) => {
-                            if (error) {
-                                console.log('Unable to remove ' + package.name);
-                                return callback(error)
-                            }
-                            else {
-                                console.log(package.name + ' successfully removed.');
-                            }
-                        });
-
-                        // Unless manually modified, should contain a single maintainer
-                        maintainers.forEach(maintainer => {
-                            let userId = maintainer._id
-
-                            // Update user 'maintains' array
-                            UserModel.findById(new mongoose.Types.ObjectId(userId), (error, user) => {
-                                if(error){
-                                    console.log('Unable to find user with matching ObjectId: ' + userId);
-                                    return callback(error);
+                    // Find package by id
+                    PackageModel.findById(new mongoose.Types.ObjectId(packageId), (error, package) => {
+                        if(error) {
+                            console.log('Unable to find package with matching ObjectId: ' + packageId);
+                            return callback(error);
+                        }
+                        else if(!package) {
+                            return callback('Query returned a null package for ObjectId: ' + packageId);
+                        }
+                        else {
+                            console.log('Found package with matching ObjectId: ' + package._id + ' - ' + package.name);
+                            
+                            // Remove Package
+                            package.remove((error) => {
+                                if (error) {
+                                    console.log('Unable to remove ' + package.name);
+                                    return callback(error)
                                 }
-                                else if(!user) {
-                                    return callback('Query returned a null user for ObjectId: ' + userId);
-                                }
-                                else if(user){
-                                    console.log('Found user with matching ObjectId: ' + user._id + ' - ' + package.name);
-                                    
-                                    // Publishers 'num_maintained_packages' value is automatically 
-                                    // updated every 20 minutes when 'synchronize_package_stats' runs
-
-                                    // Remove Package from publishers 'maintains' array
-                                    user.update( ( { $pull: { maintains: package._id } } ), (error, data) => {
-                                        if (error) {
-                                            console.log('Unable to update maintains array for ' + user.username);
-                                            return callback(error)
-                                        }
-                                        else {
-                                            console.log(package.name + ' was removed from ' + user.username + ' maintains array');
-                                        }
-                                    });
+                                else {
+                                    console.log(package.name + ' successfully removed.');
                                 }
                             });
-                        });
-                    }
-                })
-            });
+
+                            // Unless manually modified, should contain a single maintainer
+                            maintainers.forEach(maintainer => {
+                                let userId = maintainer._id
+
+                                // Update user 'maintains' array
+                                UserModel.findById(new mongoose.Types.ObjectId(userId), (error, user) => {
+                                    if(error){
+                                        console.log('Unable to find user with matching ObjectId: ' + userId);
+                                        return callback(error);
+                                    }
+                                    else if(!user) {
+                                        return callback('Query returned a null user for ObjectId: ' + userId);
+                                    }
+                                    else if(user){
+                                        console.log('Found user with matching ObjectId: ' + user._id + ' - ' + package.name);
+                                        
+                                        // Publishers 'num_maintained_packages' value is automatically 
+                                        // updated every 20 minutes when 'synchronize_package_stats' runs
+
+                                        // Remove Package from publishers 'maintains' array
+                                        user.update( ( { $pull: { maintains: package._id } } ), (error, data) => {
+                                            if (error) {
+                                                console.log('Unable to update maintains array for ' + user.username);
+                                                return callback(error)
+                                            }
+                                            else {
+                                                console.log(package.name + ' was removed from ' + user.username + ' maintains array');
+                                            }
+                                        });
+                                    }
+                                });
+                            });
+                        }
+                    })
+                });
+            }
         }
-        
+
         return callback(new Date().toString());
-        
+
     });
 };

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -5,10 +5,13 @@ let PackageModel = require('../models/package').PackageModel,
     fs = require('fs');
 
 /**
- * Parses a local JSON file containing ObjectIds
- * for packages that will attempt to be deleted.
+ * Parses all JSON files located in `s3://package-manager-deletion-requests/New-Deletions` directory
+ * that are prefixed with 'delete' and attempts to remove specified packages by ObjectIds and updates 
+ * the package author's 'Maintains' array.  The 'num_maintained_packages' value is automatically
+ * updated every 20 minuntes when the stats are calculated.  This functionality can be disabled by setting
+ * the `process.env.PACKAGE_DELETION_ENABLED` value to false.
  * 
- * callback: function that takes a string to be displayed on the notifications slack channel
+ * callback: function that takes a string/error to be sent to the #dynamo-notifications slack channel
  */
 exports.remove_packages = function(callback){
 

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -1,0 +1,79 @@
+let PackageModel = require('../models/package').PackageModel,
+    UserModel = require('../models/user').UserModel,
+    mongoose = require('mongoose'),
+    _ = require('underscore'),
+    fs = require('fs');
+
+exports.remove_packages = function(callback){
+
+    console.log('Starting package deletion scan...')
+
+    // TODO this needs to point at a specific location on machine where S3 CSV file is copied
+    let directoryPath = 'C:/Users/alfarok/Desktop/sampleCSV.csv';
+
+    // Load S3 CSV from local disk (requires another script that copies from S3 to local machine)
+    fs.readFile(directoryPath, (error, fileData) => {
+        if (error) {
+            console.log('Unable to read local CSV file');
+            return callback(error);
+        }
+        else{
+            let packageIds = fileData.toString().split(',');
+            console.log('Package Ids for Removal: ');
+            console.log(packageIds);
+            
+            // For each package id loaded from the CSV file
+            packageIds.forEach(packageId => {
+                PackageModel.findById(new mongoose.Types.ObjectId(packageId), (error, package) => {
+                    if(error || _.isEmpty(package)){
+                        return callback('Unable to find package with matching ObjectId: ' + packageId);
+                    }
+                    else {
+                        console.log('Found package with matching ObjectId: ' + package._id + ' - ' + package.name);
+
+                        let maintainers = package.maintainers;
+                        
+                        // Remove Package
+                        package.remove((error) => {
+                            if (error) {
+                                console.log('Unable to remove ' + package.name);
+                                return callback(error)
+                            }
+                            else {
+                                console.log(package.name + ' successfully removed.');
+                            }
+                        });
+
+                        // Update the package authors user data
+                        maintainers.forEach(maintainer => {
+                            
+                            let userId = maintainer.toHexString();
+
+                            UserModel.findById(new mongoose.Types.ObjectId(userId), (error, user) => {
+                                if(error || _.isEmpty(user)){
+                                    return callback('Unable to find user with matching ObjectId: ' + user.userName);
+                                }
+                                else {
+                                    console.log('Found user with matching ObjectId: ' + user._id + ' - ' + package.name);
+                                    
+                                    // Remove Package from publishers 'maintains' array
+                                    // Publishers 'num_maintained_packages' value is automatically updated every 20 minutes when 'synchronize_package_stats' runs
+                                    user.update( ( { $pull: { maintains: package._id } } ), (error, data) => {
+                                        if (error) {
+                                            console.log('Unable to update maintains array for ' + user.username);
+                                            return callback(error)
+                                        }
+                                        else {
+                                            return callback(package.name + ' was successfully removed from ' + user.username + ' maintains array');
+                                        }
+                                    });
+                                }
+                            });
+
+                        })
+                    }
+                })
+            });
+        }
+    })
+};

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -1,7 +1,7 @@
 let PackageModel = require('../models/package').PackageModel,
     UserModel = require('../models/user').UserModel,
     mongoose = require('mongoose'),
-    amazonS3 = require('awssum-amazon-s3')
+    aws = require('aws-sdk')
     fs = require('fs');
 
 /**
@@ -12,25 +12,28 @@ exports.remove_packages = function(callback){
 
     console.log('Starting package deletion scan...')
 
-    let s3 = new amazonS3.S3({
+    // Credentials
+    let s3 = new aws.S3({
         'accessKeyId'     : process.env.AWSAccessKeyId,
         'secretAccessKey' : process.env.AWSSecretKey,
-        'region'          : amazonS3.US_EAST_1
+        'region'          : aws.US_EAST_1
     });
 
-    // Load S3 data
+    // Bucket data
     let params = {
-        BucketName: 'package-manager-deletion-requests', 
-        ObjectName: 'New-Deletion/packagesToDelete.json'
+        Bucket: 'package-manager-deletion-requests', 
+        Key: 'New-Deletion/packagesToDelete.json'
     };
 
-    s3.GetObject(params, function(error, data) {
+    s3.getObject(params, function(error, data) {
         if (error) { 
             console.log(error, error.stack);
             return callback(error);
         }
         else {
             let fileContents = data.Body.toString();
+            
+            // TODO can this be composed from several json files instead?
             var deletionObjects = JSON.parse(fileContents);
             
             if(!deletionObjects) {

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -4,34 +4,50 @@ let PackageModel = require('../models/package').PackageModel,
     _ = require('underscore'),
     fs = require('fs');
 
+/**
+ * Parses a local JSON file containing ObjectIds
+ * for packages that will attempt to be deleted.
+**/
 exports.remove_packages = function(callback){
 
     console.log('Starting package deletion scan...')
 
-    // TODO this needs to point at a specific location on machine where S3 CSV file is copied
-    let directoryPath = 'C:/Users/alfarok/Desktop/sampleCSV.csv';
+    // TODO should point to current directory structure (ssl folder where S3 JSON file is copied)
+    let packageIdJson = 'C:/Users/alfarok/Documents/GReg_alfarok/packagesToDelete.json';
 
-    // Load S3 CSV from local disk (requires another script that copies from S3 to local machine)
-    fs.readFile(directoryPath, (error, fileData) => {
+    // Load S3 JSON from local disk (requires another script that copies JSON from S3 to local machine)
+    fs.readFile(packageIdJson, 'utf8', function (error, data) {
+        
         if (error) {
-            console.log('Unable to read local CSV file');
+            console.log('Unable to read JSON file');
             return callback(error);
         }
-        else{
-            let packageIds = fileData.toString().split(',');
-            console.log('Package Ids for Removal: ');
-            console.log(packageIds);
-            
-            // For each package id loaded from the CSV file
-            packageIds.forEach(packageId => {
+        else if (!data) {
+            return callback("JSON file is null");
+        }
+        else {
+            let deletionObjects = JSON.parse(data);
+
+            console.log(deletionObjects.length.toString() + ' packages to be deleted');
+
+            // For each package id loaded from the JSON file
+            deletionObjects.forEach(deletionObject => {
+
+                let packageId = deletionObject.package_id;
+                // An array of maintainers
+                let maintainers = deletionObject.maintainers;
+
+                // Find package by id
                 PackageModel.findById(new mongoose.Types.ObjectId(packageId), (error, package) => {
-                    if(error || _.isEmpty(package)){
-                        return callback('Unable to find package with matching ObjectId: ' + packageId);
+                    if(error) {
+                        console.log('Unable to find package with matching ObjectId: ' + packageId);
+                        return callback(error);
+                    }
+                    else if(!package) {
+                        return callback('Query returned a null package for ObjectId: ' + packageId);
                     }
                     else {
                         console.log('Found package with matching ObjectId: ' + package._id + ' - ' + package.name);
-
-                        let maintainers = package.maintainers;
                         
                         // Remove Package
                         package.remove((error) => {
@@ -44,36 +60,44 @@ exports.remove_packages = function(callback){
                             }
                         });
 
-                        // Update the package authors user data
+                        // Unless manually modified, should contain a single maintainer
                         maintainers.forEach(maintainer => {
-                            
-                            let userId = maintainer.toHexString();
+                            let userId = maintainer._id
 
+                            // Update user 'maintains' array
                             UserModel.findById(new mongoose.Types.ObjectId(userId), (error, user) => {
-                                if(error || _.isEmpty(user)){
-                                    return callback('Unable to find user with matching ObjectId: ' + user.userName);
+                                if(error){
+                                    console.log('Unable to find user with matching ObjectId: ' + userId);
+                                    return callback(error);
                                 }
-                                else {
+                                else if(!user) {
+                                    return callback('Query returned a null user for ObjectId: ' + userId);
+                                }
+                                else if(user){
                                     console.log('Found user with matching ObjectId: ' + user._id + ' - ' + package.name);
                                     
+                                    // Publishers 'num_maintained_packages' value is automatically 
+                                    // updated every 20 minutes when 'synchronize_package_stats' runs
+
                                     // Remove Package from publishers 'maintains' array
-                                    // Publishers 'num_maintained_packages' value is automatically updated every 20 minutes when 'synchronize_package_stats' runs
                                     user.update( ( { $pull: { maintains: package._id } } ), (error, data) => {
                                         if (error) {
                                             console.log('Unable to update maintains array for ' + user.username);
                                             return callback(error)
                                         }
                                         else {
-                                            return callback(package.name + ' was successfully removed from ' + user.username + ' maintains array');
+                                            console.log(package.name + ' was removed from ' + user.username + ' maintains array');
                                         }
                                     });
                                 }
                             });
-
-                        })
+                        });
                     }
                 })
             });
         }
-    })
+        
+        return callback(new Date().toString());
+        
+    });
 };

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -31,7 +31,7 @@ exports.remove_packages = function(callback){
             return callback(error);
         }
         else if(data.Contents.length === 0) {
-            return callback(msg);
+            return callback('Found 0 matching deletion files in S3 package-manager-deletion-requests/New-Deletions/');
         }
         else { 
             let keys = data.Contents;

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -19,12 +19,40 @@ exports.remove_packages = function(callback){
         'region'          : aws.US_EAST_1
     });
 
-    // Bucket data
-    let params = {
-        Bucket: 'package-manager-deletion-requests', 
-        Key: 'New-Deletion/packagesToDelete.json'
+    // JSON files used for deletion located in'package-manager-deletion-requests/New-Deletion`
+    let params = { 
+        Bucket: 'package-manager-deletion-requests',
+        Delimiter: '/',
+        Prefix: 'New-Deletions/delete' // File names should be prefixed with 'delete'
     };
 
+    s3.listObjects(params, function(error, data) {
+        if (error) { 
+            console.log(error, error.stack);
+            return callback(error);
+        }
+        else if(data.Contents.length === 0) {
+            let msg = 'Found 0 matching deletion files in S3 package-manager-deletion-requests/New-Deletions/'
+            console.log(msg);
+            return callback(msg);
+        }
+        else { 
+            let keys = data.Contents;
+            console.log('Found ' + keys.length + ' matching deletion files in S3 package-manager-deletion-requests/New-Deletions/');
+
+            keys.forEach(keyObject => {
+                let params = {
+                    Bucket: 'package-manager-deletion-requests', 
+                    Key: keyObject.Key
+                };
+
+                removePackageByKey(params, s3, callback);
+            });
+        }
+    });
+};
+
+function removePackageByKey(params, s3, callback) {
     s3.getObject(params, function(error, data) {
         if (error) { 
             console.log(error, error.stack);
@@ -32,85 +60,77 @@ exports.remove_packages = function(callback){
         }
         else {
             let fileContents = data.Body.toString();
+            let deletionObject = JSON.parse(fileContents)[0];
             
-            // TODO can this be composed from several json files instead?
-            var deletionObjects = JSON.parse(fileContents);
-            
-            if(!deletionObjects) {
-                return callback("JSON file is null");
+            if(!deletionObject) {
+                return callback('JSON file is null for S3 file: ' + params.Key);
             }
             else {
-                console.log(deletionObjects.length.toString() + ' packages to be deleted');
+                console.log(deletionObject.package_name + ' packages to be deleted');
 
-                // For each package id loaded from the JSON file
-                deletionObjects.forEach(deletionObject => {
+                let packageId = deletionObject.package_id;
+                let packageName = deletionObject.package_name;
+                let maintainers = deletionObject.maintainers;
 
-                    let packageId = deletionObject.package_id;
-                    // An array of maintainers
-                    let maintainers = deletionObject.maintainers;
+                // Find package by id
+                PackageModel.findById(new mongoose.Types.ObjectId(packageId), (error, package) => {
+                    if(error) {
+                        console.log('Unable to find package with matching ObjectId: ' + packageId + ' - ' + packageName);
+                        return callback(error);
+                    }
+                    else if(!package) {
+                        return callback('Query returned a null package for ObjectId: ' + packageId + ' - ' + packageName);
+                    }
+                    else {
+                        console.log('Found package with matching ObjectId: ' + package._id + ' - ' + package.name);
+                        
+                        // Remove Package
+                        package.remove((error) => {
+                            if (error) {
+                                console.log('Unable to remove ' + package.name);
+                                return callback(error)
+                            }
+                            else {
+                                console.log(package.name + ' successfully removed.');
+                            }
+                        });
 
-                    // Find package by id
-                    PackageModel.findById(new mongoose.Types.ObjectId(packageId), (error, package) => {
-                        if(error) {
-                            console.log('Unable to find package with matching ObjectId: ' + packageId);
-                            return callback(error);
-                        }
-                        else if(!package) {
-                            return callback('Query returned a null package for ObjectId: ' + packageId);
-                        }
-                        else {
-                            console.log('Found package with matching ObjectId: ' + package._id + ' - ' + package.name);
-                            
-                            // Remove Package
-                            package.remove((error) => {
-                                if (error) {
-                                    console.log('Unable to remove ' + package.name);
-                                    return callback(error)
+                        // Unless manually modified, array should contain a single maintainer
+                        maintainers.forEach(maintainer => {
+                            let userId = maintainer._id
+
+                            // Update user 'maintains' array
+                            UserModel.findById(new mongoose.Types.ObjectId(userId), (error, user) => {
+                                if(error){
+                                    console.log('Unable to find user with matching ObjectId: ' + userId);
+                                    return callback(error);
                                 }
-                                else {
-                                    console.log(package.name + ' successfully removed.');
+                                else if(!user) {
+                                    return callback('Query returned a null user for ObjectId: ' + userId);
+                                }
+                                else if(user){
+                                    console.log('Found user with matching ObjectId: ' + user._id + ' - ' + package.name);
+
+                                    // Remove Package from publishers 'maintains' array
+                                    user.update( ( { $pull: { maintains: package._id } } ), (error, data) => {
+                                        if (error) {
+                                            console.log('Unable to update maintains array for ' + user.username);
+                                            return callback(error)
+                                        }
+                                        else {
+                                            console.log(package.name + ' was removed from ' + user.username + ' maintains array');
+                                            return callback(package.name + ' authored by ' + user.username + ' was successfully deleted')
+                                        }
+                                    });
                                 }
                             });
-
-                            // Unless manually modified, should contain a single maintainer
-                            maintainers.forEach(maintainer => {
-                                let userId = maintainer._id
-
-                                // Update user 'maintains' array
-                                UserModel.findById(new mongoose.Types.ObjectId(userId), (error, user) => {
-                                    if(error){
-                                        console.log('Unable to find user with matching ObjectId: ' + userId);
-                                        return callback(error);
-                                    }
-                                    else if(!user) {
-                                        return callback('Query returned a null user for ObjectId: ' + userId);
-                                    }
-                                    else if(user){
-                                        console.log('Found user with matching ObjectId: ' + user._id + ' - ' + package.name);
-                                        
-                                        // Publishers 'num_maintained_packages' value is automatically 
-                                        // updated every 20 minutes when 'synchronize_package_stats' runs
-
-                                        // Remove Package from publishers 'maintains' array
-                                        user.update( ( { $pull: { maintains: package._id } } ), (error, data) => {
-                                            if (error) {
-                                                console.log('Unable to update maintains array for ' + user.username);
-                                                return callback(error)
-                                            }
-                                            else {
-                                                console.log(package.name + ' was removed from ' + user.username + ' maintains array');
-                                            }
-                                        });
-                                    }
-                                });
-                            });
-                        }
-                    })
-                });
+                        });
+                    }
+                })
             }
         }
 
-        return callback(new Date().toString());
+        return callback('New package deletion request at ' + new Date().toString());
 
     });
-};
+}

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -126,7 +126,7 @@ function removePackageByKey(params, s3, callback) {
         }
 
         let date = new Date();
-        return callback('A package manager deletion request was executed on ' + date.toDateString() + ' at ' + date.toISOString());
+        return callback('A package manager deletion request was executed on ' + date.toDateString() + ' at ' + date.toLocaleTimeString());
     });
 }
 

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -125,28 +125,28 @@ function removePackageByKey(params, s3, callback) {
             }
         }
 
-        return callback('New package deletion request on ' + new Date().toUTCString());
+        return callback('New package deletion request on ' + new Date().toDateString());
 
     });
 }
 
 /**
  * Copy a JSON file on S3 'New-Deletions' to 'Executed-Deletions'
- * And delete the original source file if copy is sucessful
+ * And delete the original source file if copy is successful
  * 
  * @param params: S3 'Bucket' and 'Key' object
  * @param s3: reference to S3 credentials
  * @param callback: function that takes a string to be displayed on the notifications slack channel
  */
 function moveS3File(params, s3, callback) {
-    let updateParams = {
+    let updatedParams = {
         Bucket: params.Bucket, 
-        CopySource: '/Executed-Deletions/' + new Date().toUTCString(), 
-        Key: params.Key
+        CopySource: params.Bucket + '/' + params.Key, 
+        Key: 'Executed-Deletions/' + new Date().toISOString() + '.json' 
     }
 
-    s3.copyObject(updateParams, function(error, data) {
-        if(err) {
+    s3.copyObject(updatedParams, function(error, data) {
+        if(error) {
             callback(error);
         }
         else {
@@ -165,7 +165,7 @@ function moveS3File(params, s3, callback) {
  */
 function deleteS3File(params, s3, callback) {
     s3.deleteObject(params, function(error, data) {
-        if(err) {
+        if(error) {
            callback(error);
         }
     });

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -28,17 +28,13 @@ exports.remove_packages = function(callback){
 
     s3.listObjects(params, function(error, data) {
         if (error) { 
-            console.log(error, error.stack);
             return callback(error);
         }
         else if(data.Contents.length === 0) {
-            let msg = 'Found 0 matching deletion files in S3 package-manager-deletion-requests/New-Deletions/'
-            console.log(msg);
             return callback(msg);
         }
         else { 
             let keys = data.Contents;
-            console.log('Found ' + keys.length + ' matching deletion files in S3 package-manager-deletion-requests/New-Deletions/');
 
             keys.forEach(keyObject => {
                 let params = {
@@ -55,7 +51,6 @@ exports.remove_packages = function(callback){
 function removePackageByKey(params, s3, callback) {
     s3.getObject(params, function(error, data) {
         if (error) { 
-            console.log(error, error.stack);
             return callback(error);
         }
         else {
@@ -66,8 +61,6 @@ function removePackageByKey(params, s3, callback) {
                 return callback('JSON file is null for S3 file: ' + params.Key);
             }
             else {
-                console.log(deletionObject.package_name + ' packages to be deleted');
-
                 let packageId = deletionObject.package_id;
                 let packageName = deletionObject.package_name;
                 let maintainers = deletionObject.maintainers;
@@ -75,23 +68,16 @@ function removePackageByKey(params, s3, callback) {
                 // Find package by id
                 PackageModel.findById(new mongoose.Types.ObjectId(packageId), (error, package) => {
                     if(error) {
-                        console.log('Unable to find package with matching ObjectId: ' + packageId + ' - ' + packageName);
                         return callback(error);
                     }
                     else if(!package) {
                         return callback('Query returned a null package for ObjectId: ' + packageId + ' - ' + packageName);
                     }
                     else {
-                        console.log('Found package with matching ObjectId: ' + package._id + ' - ' + package.name);
-                        
                         // Remove Package
                         package.remove((error) => {
                             if (error) {
-                                console.log('Unable to remove ' + package.name);
                                 return callback(error)
-                            }
-                            else {
-                                console.log(package.name + ' successfully removed.');
                             }
                         });
 
@@ -102,23 +88,20 @@ function removePackageByKey(params, s3, callback) {
                             // Update user 'maintains' array
                             UserModel.findById(new mongoose.Types.ObjectId(userId), (error, user) => {
                                 if(error){
-                                    console.log('Unable to find user with matching ObjectId: ' + userId);
                                     return callback(error);
                                 }
                                 else if(!user) {
                                     return callback('Query returned a null user for ObjectId: ' + userId);
                                 }
-                                else if(user){
-                                    console.log('Found user with matching ObjectId: ' + user._id + ' - ' + package.name);
-
+                                else {
                                     // Remove Package from publishers 'maintains' array
                                     user.update( ( { $pull: { maintains: package._id } } ), (error, data) => {
                                         if (error) {
-                                            console.log('Unable to update maintains array for ' + user.username);
                                             return callback(error)
                                         }
                                         else {
-                                            console.log(package.name + ' was removed from ' + user.username + ' maintains array');
+                                            // TODO move JSON file by key to 'Executed-Deletions`
+                                            // TODO delete JSON file from 'New-Deletions'
                                             return callback(package.name + ' authored by ' + user.username + ' was successfully deleted')
                                         }
                                     });

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -64,7 +64,15 @@ function removePackageByKey(params, s3, callback) {
         }
         else {
             let fileContents = data.Body.toString();
-            let deletionObject = JSON.parse(fileContents)[0];
+            let s3File = JSON.parse(fileContents);
+
+            // This was designed so that in the future the `package_id` route can be automatically
+            // consumed, which will always return a single package in the JSON response
+            if(s3File.length > 1) {
+                return callback('JSON file should only contain a single package, aborting...');
+            }
+
+            let deletionObject = s3File[0];
             
             if(!deletionObject) {
                 return callback('JSON file is null for S3 file: ' + params.Key);

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1550,7 +1550,10 @@ exports.by_package_name = function(name, callback) {
 
 	PackageModel
 	.find( {name: name} )
-  	.populate('_id', 'username')
+	.populate('maintainers', 'username')
+	.populate('versions.direct_dependency_ids', 'name')
+	.populate('versions.full_dependency_ids', 'name')
+	.populate('used_by', 'name')
   	.exec(callback);
 
 };

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1539,6 +1539,23 @@ exports.by_engine_and_name = function(engine, name, callback) {
 };
 
 /**
+ * Obtain a package by name
+ *
+ * @param {string} The name of the package
+ * @param {Function} Callback to execute after inserting. The arguments are an error object (null if successful) and the pkg.
+ * @api public
+ */
+
+exports.by_package_name = function(name, callback) {
+
+	PackageModel
+	.find( {name: name} )
+  	.populate('_id', 'username')
+  	.exec(callback);
+
+};
+
+/**
  * Obtain a package by id
  *
  * @param {string} The id of the package

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1542,7 +1542,7 @@ exports.by_engine_and_name = function(engine, name, callback) {
  * Obtain a package by name
  *
  * @param {string} The name of the package
- * @param {Function} Callback to execute after inserting. The arguments are an error object (null if successful) and the pkg.
+ * @param {Function} Callback Error object or pkg data
  * @api public
  */
 

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -17,7 +17,8 @@ nconf.defaults({
     "FORGE_UPDATE_URL":"",
     "FORGE_GDPR_ID":"",
     "EMAIL_DISTRIBUTION":"",
-    "SLACK_WEBHOOK":""
+    "SLACK_WEBHOOK":"",
+    "SLACK_WEBHOOK_DYNAMO_NOTIFY":""
 });
 
 module.exports = {
@@ -25,7 +26,8 @@ module.exports = {
         login: nconf.get("MAILGUN_LOGIN"),
         password: nconf.get("MAILGUN_PASSWORD"),
         email: nconf.get("EMAIL_DISTRIBUTION"),
-        slackWebhook: nconf.get("SLACK_WEBHOOK")
+        slackWebhook: nconf.get("SLACK_WEBHOOK"),
+        dynamoNotify: nconf.get("SLACK_WEBHOOK_DYNAMO_NOTIFY")
     },
 
     forge: {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "async": "0.2.6",
+    "aws-sdk": "^2.312.0",
     "awssum": "^1.2.0",
     "awssum-amazon": "^1.4.0",
     "awssum-amazon-s3": "1.2.4",

--- a/routes/package.js
+++ b/routes/package.js
@@ -474,6 +474,31 @@ exports.by_engine_and_name = function(req, res) {
 };
 
 /**
+ * Lookup a package by name.  Returns package id for matches.
+ *
+ * @param {Object} HTTP request 
+ * @param {Object} HTTP response
+ * @api public
+ */
+
+exports.by_package_name = function(req, res) {
+
+  var name = req.params.name;
+  packages.by_package_name( name, function(err, pkg) {
+
+    if ( err || !pkg )
+    {
+      return res.send( 404, error.fail("There is no package with that package name") );
+    }
+
+    var data = error.success_with_content('Found package', pkg);
+    return res.send( data );
+
+  });
+
+};
+
+/**
  * Add a new package
  *
  * @param {Object} HTTP request 

--- a/routes/package.js
+++ b/routes/package.js
@@ -492,7 +492,22 @@ exports.by_package_name = function(req, res) {
     }
 
     var data = error.success_with_content('Found package', pkg);
-    return res.send( data );
+
+    var output = [];
+
+    data.content.forEach(element => {
+
+      var match = {
+        package_name: element.name,
+        package_id: element.id,
+        maintainers: element.maintainers
+      }
+
+      output.push(match);
+
+    });
+
+    return res.send( output );
 
   });
 


### PR DESCRIPTION
## Purpose

[QNTM-4240](https://jira.autodesk.com/browse/QNTM-4240)

This PR adds the ability to delete packages via the GReg application.  This is done by reading JSON files located in the  `package-manager-deletion-requests ` S3 bucket.

- Locate a package id by package name (using the new route)
- Copy the route response to a JSON file located in S3 (1 deletion request per file)
- Once a day the application pulls the S3 files
- If JSON data is presents
  - Attempt to delete the specified packages
  - Attempt to update the users 'maintains' array
- Copy JSON file from `New-Deletions` to `Executed-Deletions` (delete source if successful)
- Provide slack feedback when actions or failures occur

**(This process should take place after the [email protocol](https://wiki.autodesk.com/pages/viewpage.action?pageId=419450305) has been completed)**

This workflow was structured so that in the future the new route can be automatically consumed by the `remove_packages` function without the need for S3 and the JSON file.  The AC for this task calls for a more manual process until the future of package manager is more clearly defined.  This may also eventually become part of the UI where users have the ability to delete their maintained packages on their own.

## Examples

### Route Response Examples:

dynamopackages.com/package_id/Sample View Extension
delete_SampleViewExtension.JSON
```json
[
  {
    "package_name": "Sample View Extension",
    "package_id": "5b92b0715f5895c421000003",
    "maintainers": [
      {
        "_id": "5b915a3cb9bd65bc02000003",
        "username": "keith.alfaro"
      }
    ]
  }
]
```

dynamopackages.com/package_id/MeshToolkit
delete_MeshToolkit.JSON
```json
[
  {
    "package_name": "MeshToolkit",
    "package_id": "5b92b0a85f5895c421000005",
    "maintainers": [
      {
        "_id": "5b915a3cb9bd65bc02000003",
        "username": "keith.alfaro"
      }
    ]
  }
]
```

Successful Callback/Slack Notifications Examples:
```
A package manager deletion request was executed on Thu Sep 13 2018 at 3:02:55 PM
Sample View Extension authored by keith.alfaro was successfully deleted
A package manager deletion request was executed on Thu Sep 13 2018 at 3:02:55 PM
MeshToolkit authored by keith.alfaro was successfully deleted
```

Failed Callback/Slack Notifications Examples:
```
A package manager deletion request was executed on Thu Sep 13 2018 at 3:12:25 PM
Query returned a null package for ObjectId: 5b92b0a85f5895c421000005 - MeshToolkit
A package manager deletion request was executed on Thu Sep 13 2018 at 3:12:25 PM
Query returned a null package for ObjectId: 5b92b0715f5895c421000003 - Sample View Extension
```

No JSON Files Found in S3 Callback/Slack Notifications Example:
```
No deletion files found in S3 package-manager-deletion-requests/New-Deletions/
```


## Tasks
- [x] Create a route in package manager that returns package id when supplied package name
- [x] Consume S3 JSON data before executing deletion request in the GReg app
- [x] Create a function in GReg app that and completes deletions based on JSON response data
- [x] Provide slack notifications tracking actions and results

## Architecture
![package_deletion_diagram](https://user-images.githubusercontent.com/13341935/45512507-dd7bda80-b76d-11e8-83b6-2e066d8b94b3.png)

## Reviewers
@mjkkirschner @ramramps 
