### PR TITLE
address different hash result for non ascii characters in old node

### DIFF
--- a/lib/gdpr.js
+++ b/lib/gdpr.js
@@ -154,12 +154,12 @@ exports.handleGDPRRRequest = function (req, res) {
     //has does not match.
     const hash = 'sha1hash=' +
         crypto.createHmac('sha1', secret)
-            .update(JSON.stringify(req.body))
+            .update(JSON.stringify(req.body), 'utf8')
             .digest('hex');
 
     if (userInfo.email != "" && req.headers['x-adsk-signature'] == hash) {
         //check the user info in the database.
-        UserModel.findOne({ $or: [{ email: userInfo.email} ,{ oxygen_id : userInfo.id }] }, function (err, user) {
+        UserModel.findOne({ $or: [{ email: userInfo.email }, { oxygen_id: userInfo.id }] }, function (err, user) {
             if (err) {
                 console.log("error in finding the user", err);
                 res.send(err);
@@ -184,6 +184,7 @@ exports.handleGDPRRRequest = function (req, res) {
         res.status(200).send("Task updated");
     }
     else {
+        console.log("sending 403 - invalid hash.")
         res.status(403).send("Not called from webhook service");
     }
 }

--- a/lib/gdpr.js
+++ b/lib/gdpr.js
@@ -154,6 +154,7 @@ exports.handleGDPRRRequest = function (req, res) {
     //has does not match.
     const hash = 'sha1hash=' +
         crypto.createHmac('sha1', secret)
+        //pass utf-8 explicitly as the default encoding changed in node >6.x
             .update(JSON.stringify(req.body), 'utf8')
             .digest('hex');
 
@@ -184,7 +185,7 @@ exports.handleGDPRRRequest = function (req, res) {
         res.status(200).send("Task updated");
     }
     else {
-        console.log("sending 403 - invalid hash.")
-        res.status(403).send("Not called from webhook service");
+        console.log("sending 403 - invalid hash ");
+        res.status(403).send("Not called from webhook service, invalid hash");
     }
 }


### PR DESCRIPTION
I believe related to:
https://stackoverflow.com/questions/37213211/why-crypto-createhash-returns-different-output-in-new-version

I have tested this one dev and it appears to work nicely there for the currently open/error tasks.
@ramramps lets talk tomorrow about deploying the same thing to flood?