### PR TITLE
Replace 'let' with 'var'

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,7 +158,7 @@ app.post('/gdprDeleteRequest', gdpr.handleGDPRRRequest);
 // Pkg Deletion Requests
 ////////////////////////
 
-let packageDeletionEnabled = process.env.PACKAGE_DELETION_ENABLED === 'true' ? true : false; 
+var packageDeletionEnabled = process.env.PACKAGE_DELETION_ENABLED === 'true' ? true : false; 
 
 if(packageDeletionEnabled) {
   setInterval(function(){

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -1,4 +1,4 @@
-let PackageModel = require('../models/package').PackageModel,
+var PackageModel = require('../models/package').PackageModel,
     UserModel = require('../models/user').UserModel,
     mongoose = require('mongoose'),
     aws = require('aws-sdk')
@@ -18,14 +18,14 @@ exports.remove_packages = function(callback){
     console.log('Starting package deletion scan...')
 
     // Credentials
-    let s3 = new aws.S3({
+    var s3 = new aws.S3({
         'accessKeyId'     : process.env.AWSAccessKeyId,
         'secretAccessKey' : process.env.AWSSecretKey,
         'region'          : aws.US_EAST_1
     });
 
     // JSON files used for deletion located in'package-manager-deletion-requests/New-Deletion`
-    let params = { 
+    var params = { 
         Bucket: 'package-manager-deletion-requests',
         Delimiter: '/',
         Prefix: 'New-Deletions/delete' // File names should be prefixed with 'delete'
@@ -39,10 +39,10 @@ exports.remove_packages = function(callback){
             return callback('No deletion files found in S3 package-manager-deletion-requests/New-Deletions/');
         }
         else { 
-            let keys = data.Contents;
+            var keys = data.Contents;
 
             keys.forEach(keyObject => {
-                let params = {
+                var params = {
                     Bucket: 'package-manager-deletion-requests', 
                     Key: keyObject.Key
                 };
@@ -66,8 +66,8 @@ function removePackageByKey(params, s3, callback) {
             return callback(error);
         }
         else {
-            let fileContents = data.Body.toString();
-            let s3File = JSON.parse(fileContents);
+            var fileContents = data.Body.toString();
+            var s3File = JSON.parse(fileContents);
 
             // This was designed so that in the future the `package_id` route can be automatically
             // consumed, which will always return a single package in the JSON response
@@ -75,15 +75,15 @@ function removePackageByKey(params, s3, callback) {
                 return callback('JSON file should only contain a single package, aborting...');
             }
 
-            let deletionObject = s3File[0];
+            var deletionObject = s3File[0];
             
             if(!deletionObject) {
                 return callback('JSON file is null for S3 file: ' + params.Key);
             }
             else {
-                let packageId = deletionObject.package_id;
-                let packageName = deletionObject.package_name;
-                let maintainers = deletionObject.maintainers;
+                var packageId = deletionObject.package_id;
+                var packageName = deletionObject.package_name;
+                var maintainers = deletionObject.maintainers;
 
                 // Find package by id
                 PackageModel.findById(new mongoose.Types.ObjectId(packageId), (error, package) => {
@@ -103,7 +103,7 @@ function removePackageByKey(params, s3, callback) {
 
                         // Unless manually modified, array should contain a single maintainer
                         maintainers.forEach(maintainer => {
-                            let userId = maintainer._id
+                            var userId = maintainer._id
 
                             // Update user 'maintains' array
                             UserModel.findById(new mongoose.Types.ObjectId(userId), (error, user) => {
@@ -136,7 +136,7 @@ function removePackageByKey(params, s3, callback) {
             }
         }
 
-        let date = new Date();
+        var date = new Date();
         return callback('A package manager deletion request was executed on ' + date.toDateString() + ' at ' + date.toLocaleTimeString());
     });
 }
@@ -150,7 +150,7 @@ function removePackageByKey(params, s3, callback) {
  * @param callback: function that takes a string to be displayed on the notifications slack channel
  */
 function moveS3File(params, s3, callback) {
-    let updatedParams = {
+    var updatedParams = {
         Bucket: params.Bucket, 
         CopySource: params.Bucket + '/' + params.Key, 
         Key: 'Executed-Deletions/' + new Date().toISOString() + '.json' 


### PR DESCRIPTION
## Purpose
[GReg #20](https://github.com/DynamoDS/GReg/pull/20) declared several variables using `let` when `var` is required.  This PR replaces those instances and fixes any issues with deploying the new changes on dev.

## Reviewers
@ramramps 