### PR TITLE
Cleanup package deletion callbacks

### DIFF
--- a/app.js
+++ b/app.js
@@ -160,6 +160,8 @@ app.post('/gdprDeleteRequest', gdpr.handleGDPRRRequest);
 
 // Check if package deletion functionality is enabled on the machine
 var packageDeletionEnabled = process.env.PACKAGE_DELETION_ENABLED === 'true' ? true : false; 
+// Determine if running on Prod or Dev
+var environment = process.env.NODE_ENV === 'production' ? 'PROD' : 'DEV'; 
 
 if(packageDeletionEnabled) {
   console.log("Package manager deletion tool is enabled")
@@ -171,7 +173,7 @@ if(packageDeletionEnabled) {
         uri: secrets.mailgun.dynamoNotify,
         method: 'POST',
         json: {
-          "text" : data.toString()
+          "text" : environment + ': ' + data.toString()
         }
       };
       

--- a/app.js
+++ b/app.js
@@ -161,9 +161,7 @@ app.post('/gdprDeleteRequest', gdpr.handleGDPRRRequest);
 // Check if package deletion functionality is enabled on the machine
 var packageDeletionEnabled = process.env.PACKAGE_DELETION_ENABLED === 'true' ? true : false; 
 
-if(packageDeletionEnabled === false) { console.log("Package manager deletion tool is disabled")}
-
-else if(packageDeletionEnabled) {
+if(packageDeletionEnabled) {
   console.log("Package manager deletion tool is enabled")
 
   setInterval(function(){
@@ -184,6 +182,7 @@ else if(packageDeletionEnabled) {
     });
   }, 1000 * 60 * 60 * 24); // daily
 }
+else { console.log("Package manager deletion tool is disabled") }
 
 ////////////////////////
 // Server

--- a/app.js
+++ b/app.js
@@ -158,9 +158,14 @@ app.post('/gdprDeleteRequest', gdpr.handleGDPRRRequest);
 // Pkg Deletion Requests
 ////////////////////////
 
+// Check if package deletion functionality is enabled on the machine
 var packageDeletionEnabled = process.env.PACKAGE_DELETION_ENABLED === 'true' ? true : false; 
 
-if(packageDeletionEnabled) {
+if(packageDeletionEnabled === false) { console.log("Package manager deletion tool is disabled")}
+
+else if(packageDeletionEnabled) {
+  console.log("Package manager deletion tool is enabled")
+
   setInterval(function(){
     package_deletion.remove_packages(function(data) { 
       // Data returned from callback will be sent to Slack #dynamo-notify

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -151,7 +151,10 @@ function removePackageByKey(params, s3, callback) {
 
         },
 
-    ]);
+    ], function (error) {
+            if (error) { return callback(error); }
+        }
+    );
 
     // Notify an execution attempt occured
     var date = new Date();

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -1,7 +1,8 @@
 var PackageModel = require('../models/package').PackageModel,
     UserModel = require('../models/user').UserModel,
     mongoose = require('mongoose'),
-    aws = require('aws-sdk')
+    aws = require('aws-sdk'),
+    async = require('async'),
     fs = require('fs');
 
 /**
@@ -61,84 +62,101 @@ exports.remove_packages = function(callback){
  * @param callback: function that takes a string to be displayed on the notifications slack channel
  */
 function removePackageByKey(params, s3, callback) {
-    s3.getObject(params, function(error, data) {
-        if (error) { 
-            return callback(error);
-        }
-        else {
-            var fileContents = data.Body.toString();
-            var s3File = JSON.parse(fileContents);
 
-            // This was designed so that in the future the `package_id` route can be automatically
-            // consumed, which will always return a single package in the JSON response
-            if(s3File.length > 1) {
-                return callback('JSON file should only contain a single package, aborting...');
-            }
-
-            var deletionObject = s3File[0];
+    // Waterfall runs functions in series, passing results to the next function
+	// If any function returns error object, the whole thing terminates
+    async.waterfall([ 
+        
+        // Get all files 'package-manager-deletion-requests' prefixed with 'delete'
+        function(local_Callback) {
             
-            if(!deletionObject) {
-                return callback('JSON file is null for S3 file: ' + params.Key);
-            }
-            else {
-                var packageId = deletionObject.package_id;
-                var packageName = deletionObject.package_name;
-                var maintainers = deletionObject.maintainers;
+            s3.getObject(params, function(error, data) {
+                
+                if(error) { return callback(error); }
 
-                // Find package by id
-                PackageModel.findById(new mongoose.Types.ObjectId(packageId), (error, package) => {
-                    if(error) {
-                        return callback(error);
-                    }
-                    else if(!package) {
-                        return callback('Query returned a null package for ObjectId: ' + packageId + ' - ' + packageName);
-                    }
-                    else {
-                        // Remove Package
-                        package.remove((error) => {
-                            if (error) {
-                                return callback(error)
-                            }
-                        });
+                var fileContents = data.Body.toString();
+                var s3File = JSON.parse(fileContents);
 
-                        // Unless manually modified, array should contain a single maintainer
-                        maintainers.forEach(maintainer => {
-                            var userId = maintainer._id
+                // This was designed so that in the future the `package_id` route can be automatically
+                // consumed, which will always return a single package in the JSON response
+                if(s3File.length !== 1) { return callback('JSON file should only contain a single package, aborting...'); }
 
-                            // Update user 'maintains' array
-                            UserModel.findById(new mongoose.Types.ObjectId(userId), (error, user) => {
-                                if(error){
-                                    return callback(error);
-                                }
-                                else if(!user) {
-                                    return callback('Query returned a null user for ObjectId: ' + userId);
-                                }
-                                else {
-                                    // Remove Package from publishers 'maintains' array
-                                    user.update( ( { $pull: { maintains: package._id } } ), (error, data) => {
-                                        if (error) {
-                                            return callback(error)
-                                        }
-                                        else {
-                                            // At this point all DB work is complete without errors
-                                            // Attempt to copy JSON file in S3 from 'New-Deletions' to 'Executed-Deletions' dir
-                                            moveS3File(params, s3, callback);
-                                            
-                                            // Complete
-                                            return callback(package.name + ' authored by ' + user.username + ' was successfully deleted')
-                                        }
-                                    });
-                                }
-                            });
-                        });
-                    }
-                })
-            }
-        }
+                // JSON response (https://dynamopackages.com/package_id/MY_PACKAGE_NAME)
+                var deletionObject = s3File[0];
+                
+                if(!deletionObject) { return callback('JSON file is null for S3 file: ' + params.Key); }
 
-        var date = new Date();
-        return callback('A package manager deletion request was executed on ' + date.toDateString() + ' at ' + date.toLocaleTimeString());
-    });
+                // Return 
+                local_Callback(null, deletionObject); // deletionObject is passed to the next func
+
+            });
+
+        },
+
+        // Remove package by Id
+        function(deletionObject, local_Callback) {
+            
+            var packageId = deletionObject.package_id;
+            var packageName = deletionObject.package_name;
+            var maintainers = deletionObject.maintainers;
+
+            PackageModel.findById(new mongoose.Types.ObjectId(packageId), (error, package) => {
+                
+                if(error) { return callback(error); }
+                
+                if(!package) { return callback('Query returned a null package for ObjectId: ' + packageId + ' - ' + packageName); }
+
+                // Remove Package
+                package.remove((error) => {
+                    if (error) { return callback(error) }
+                });
+
+                // Return
+                local_Callback(null, package, maintainers); // package and maintainers object passed to the next func
+
+            });
+
+        },
+
+        // Update maintainers
+        function(package, maintainers, local_Callback) {
+            
+            maintainers.forEach(maintainer => {
+                
+                var userId = maintainer._id
+
+                // Update user 'maintains' array
+                UserModel.findById(new mongoose.Types.ObjectId(userId), (error, user) => {
+                    
+                    if(error) { return callback(error); }
+                    
+                    if(!user) { return callback('Query returned a null user for ObjectId: ' + userId); }
+                    
+                    // Remove Package from publishers 'maintains' array
+                    user.update( ( { $pull: { maintains: package._id } } ), (error, data) => {
+                        
+                        if(error) { return callback(error) }
+                        
+                        // At this point all DB work is complete without errors
+                        // Attempt to copy JSON file in S3 from 'New-Deletions' to 'Executed-Deletions' dir
+                        moveS3File(params, s3, callback);
+                        
+                        // Complete
+                        return callback(package.name + ' authored by ' + user.username + ' was successfully deleted')
+                    });
+
+                });
+
+            });
+
+        },
+
+    ]);
+
+    // Notify an execution attempt occured
+    var date = new Date();
+    return callback('A package manager deletion request was executed on ' + date.toDateString() + ' at ' + date.toLocaleTimeString());
+
 }
 
 /**

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -67,7 +67,7 @@ function removePackageByKey(params, s3, callback) {
 	// If any function returns error object, the whole thing terminates
     async.waterfall([ 
         
-        // Get all files 'package-manager-deletion-requests' prefixed with 'delete'
+        // Retrieve S3 JSON object
         function(local_Callback) {
             
             s3.getObject(params, function(error, data) {

--- a/lib/package_deletion.js
+++ b/lib/package_deletion.js
@@ -18,6 +18,8 @@ exports.remove_packages = function(callback){
 
     console.log('Starting package deletion scan...')
 
+    var environment = process.env.NODE_ENV === 'production' ? 'prod' : 'dev'; 
+
     // Credentials
     var s3 = new aws.S3({
         'accessKeyId'     : process.env.AWSAccessKeyId,
@@ -27,7 +29,7 @@ exports.remove_packages = function(callback){
 
     // JSON files used for deletion located in'package-manager-deletion-requests/New-Deletion`
     var params = { 
-        Bucket: 'package-manager-deletion-requests',
+        Bucket: 'package-manager-deletion-requests-' + environment,
         Delimiter: '/',
         Prefix: 'New-Deletions/delete' // File names should be prefixed with 'delete'
     };
@@ -37,14 +39,14 @@ exports.remove_packages = function(callback){
             return callback(error);
         }
         else if(data.Contents.length === 0) {
-            return callback('No deletion files found in S3 package-manager-deletion-requests/New-Deletions/');
+            return callback('No deletion files found in S3 package-manager-deletion-requests-' + environment + '/New-Deletions directory');
         }
         else { 
             var keys = data.Contents;
 
             keys.forEach(keyObject => {
                 var params = {
-                    Bucket: 'package-manager-deletion-requests', 
+                    Bucket: 'package-manager-deletion-requests-' + environment,
                     Key: keyObject.Key
                 };
 


### PR DESCRIPTION
## Purpose
This PR cleans up the heavy if, else if, else callbacks introduced in PR #20.  It replaces the previous format with `async.waterfall` which is used in other areas of the PM code base.  Waterfall runs functions in series, passing results to the next function.  If any function returns an error object, the whole thing terminates passing the error the outer callback which finally gets sent to slack via webhook.

## Reviewers
@mjkkirschner 