### PR TITLE
GDPR task update should deal with empty emails and ox-ids

### DIFF
--- a/lib/gdpr.js
+++ b/lib/gdpr.js
@@ -184,13 +184,13 @@ exports.handleGDPRRRequest = function (req, res) {
             }
         });
     }
-    //if both email and ox id are empty, we assume this is not a real user.
+    //if both email and ox id are empty, we assume this is not a real user and close the task.
     else if (userInfo.email == "" && userInfo.id == "" && req.headers['x-adsk-signature'] == hash) {
         updateGDPRTask(req, res);
         res.status(200).send("Task updated");
     }
     else {
-        console.log("NOT CALLED FROM AUTHORIZED SERVICE")
-        res.status(403).send("Not called from webhook service");
+        console.log("handle GDPRRequest not called from an authorized service");
+        res.status(403).send("handle GDPRRequest not called from an authorized service");
     }
 }

--- a/lib/gdpr.js
+++ b/lib/gdpr.js
@@ -190,7 +190,7 @@ exports.handleGDPRRRequest = function (req, res) {
         res.status(200).send("Task updated");
     }
     else {
-        console.log("handle GDPRRequest not called from an authorized service");
-        res.status(403).send("handle GDPRRequest not called from an authorized service");
+        console.log("sending 403 - invalid hash ");
+        res.status(403).send("Not called from webhook service, invalid hash");
     }
 }

--- a/lib/gdpr.js
+++ b/lib/gdpr.js
@@ -198,7 +198,7 @@ exports.handleGDPRRRequest = function (req, res) {
                 var taskId = req.body.payload.taskId;
                 var message = "GDPR Package Manager : Delete request for the task " + taskId;
                 sendNotification(message,testMode);
-                res.send({ statusCode: 200 });
+                res.status(200).send(message);
             }
         });
     }

--- a/lib/gdpr.js
+++ b/lib/gdpr.js
@@ -33,12 +33,16 @@ exports.postPut = function (req, res, next) {
  * This function sends slack notification.
  * @param {*} message 
  */
-function sendSlackNotification(message) {
+function sendSlackNotification(message, testMode) {
     var url = secrets.mailgun.slackWebhook;
     var data = 'payload=' + JSON.stringify({
         "text": message
     });
+    if (testMode) {
 
+        console.log("SlackMessage:", data);
+        return;
+    }
     agent.post(url)
         .set('accept', 'json')
         .send(data)
@@ -48,11 +52,13 @@ function sendSlackNotification(message) {
 }
 
 /**
- * This function sends email notification
- * @param {*} message 
+ * This function sends notifications to notification channels
+ * @param {*} message - message to send
+ * @param {*} testMode - logs instead of sending out real notifications.
+
  */
-function sendNotification(message) {
-    sendSlackNotification(message);
+function sendNotification(message, testMode) {
+    sendSlackNotification(message, testMode);
     // MailGun sometimes doesn't work.
     // smtpTransport().sendMail({
     //     from: "GDPR request",
@@ -69,9 +75,12 @@ function sendNotification(message) {
 /**
  * This function updates the GDPR task. Email / Slack notifications are 
  * sent incase of any error.
- * @param {*} req 
+ * @param {*} req - original webhook request
+ * @param {*} res - response to send
+ * @param {*} testMode - in testMode this function does not make actual requests. 
+
  */
-function updateGDPRTask(req, res) {
+function updateGDPRTask(req, res, testMode) {
     var taskId = req.body.payload.taskId;
     var userInfo = req.body.payload.user_info;
     var ret = {};
@@ -104,6 +113,16 @@ function updateGDPRTask(req, res) {
         }
     }
     var authUrl = secrets.forge.auth_url;
+    var updateUrl = secrets.forge.update_url;
+
+    //don't make the request in testmode.
+    if (testMode) {
+        console.log("testMode: calling update GDPR task, payload:")
+        console.log('body:', ret.body);
+        console.log('uri:', updateUrl);
+        return;
+    }
+
     request({
         headers: headers,
         uri: authUrl,
@@ -117,7 +136,6 @@ function updateGDPRTask(req, res) {
             resp = body;
         }
         if (!err && response.statusCode === 200) {
-            var updateUrl = secrets.forge.update_url;
             agent.post(updateUrl)
                 .set('Authorization', 'Bearer ' + resp.access_token)
                 .set('accept', 'json')
@@ -138,17 +156,15 @@ function updateGDPRTask(req, res) {
 }
 
 /**
- * This function handles the incoming GDPR request
- * @param {*} req TaskID is embedeed inside the request object
- * @param {*} res 
+ * This function handles the incoming GDPR request - if in test mode this function
+ * won't actually update tasks or post to slack.
+ * @param {*} req TaskID is embedded inside the request object's body.payload
+ * @param {*} res - response back to caller of the webhook
  */
 exports.handleGDPRRRequest = function (req, res) {
+    var testMode = process.env.NODE_ENV == "test" ? true : false
+
     var userInfo = req.body.payload.user_info;
-    const ret = {
-        isBase64Encoded: false,
-        statusCode: 500,
-        body: ""
-    }
     const secret = secrets.forge.gdpr_id;
     //check whether the hash matches. Ignore the request if 
     //has does not match.
@@ -157,14 +173,14 @@ exports.handleGDPRRRequest = function (req, res) {
             .update(JSON.stringify(req.body))
             .digest('hex');
 
-        // if user email or id is valid and signature is valid then try to find user.
-    if ( (userInfo.email != "" || userInfo.oxygen_id != "") && req.headers['x-adsk-signature'] == hash) {
+    // if user email or id is valid and signature is valid then try to find user.
+    if ((userInfo.email != "" || userInfo.oxygen_id != "") && req.headers['x-adsk-signature'] == hash) {
         // check the user info in the database. - but ignore empty strings that might match.
         // we don't want to match another user with an empty string for id or email for example.
         let email = userInfo.email == "" ? "INVALID" : userInfo.email;
-        let oxygen_id = userInfo.id == "" ? "INVALID": userInfo.id;
+        let oxygen_id = userInfo.id == "" ? "INVALID" : userInfo.id;
 
-        UserModel.findOne({ $or: [{ email: email} ,{ oxygen_id : oxygen_id }] }, function (err, user) {
+        UserModel.findOne({ $or: [{ email: email }, { oxygen_id: oxygen_id }] }, function (err, user) {
             if (err) {
                 console.log("error in finding the user", err);
                 res.send(err);
@@ -172,24 +188,25 @@ exports.handleGDPRRRequest = function (req, res) {
             //if the user is not found, then update the GDPR task
             if (!user) {
                 console.log("user not found");
-                updateGDPRTask(req, res);
+                updateGDPRTask(req, res,testMode);
                 res.status(200).send("Task updated");
             }
             //Send email / slack notifications for valid users
             else {
                 var taskId = req.body.payload.taskId;
                 var message = "GDPR Package Manager : Delete request for the task " + taskId;
-                sendNotification(message);
+                sendNotification(message,testMode);
                 res.send({ statusCode: 200 });
             }
         });
     }
     //if both email and ox id are empty, we assume this is not a real user and close the task.
     else if (userInfo.email == "" && userInfo.id == "" && req.headers['x-adsk-signature'] == hash) {
-        updateGDPRTask(req, res);
+        updateGDPRTask(req, res,testMode);
         res.status(200).send("Task updated");
     }
     else {
+        console.log(hash);
         console.log("sending 403 - invalid hash ");
         res.status(403).send("Not called from webhook service, invalid hash");
     }

--- a/lib/gdpr.js
+++ b/lib/gdpr.js
@@ -157,9 +157,14 @@ exports.handleGDPRRRequest = function (req, res) {
             .update(JSON.stringify(req.body))
             .digest('hex');
 
-    if (userInfo.email != "" && req.headers['x-adsk-signature'] == hash) {
-        //check the user info in the database.
-        UserModel.findOne({ $or: [{ email: userInfo.email} ,{ oxygen_id : userInfo.id }] }, function (err, user) {
+        // if user email or id is valid and signature is valid then try to find user.
+    if ( (userInfo.email != "" || userInfo.oxygen_id != "") && req.headers['x-adsk-signature'] == hash) {
+        // check the user info in the database. - but ignore empty strings that might match.
+        // we don't want to match another user with an empty string for id or email for example.
+        let email = userInfo.email == "" ? "INVALID" : userInfo.email;
+        let oxygen_id = userInfo.id == "" ? "INVALID": userInfo.id;
+
+        UserModel.findOne({ $or: [{ email: email} ,{ oxygen_id : oxygen_id }] }, function (err, user) {
             if (err) {
                 console.log("error in finding the user", err);
                 res.send(err);
@@ -179,11 +184,13 @@ exports.handleGDPRRRequest = function (req, res) {
             }
         });
     }
-    else if (req.headers['x-adsk-signature'] == hash) {
+    //if both email and ox id are empty, we assume this is not a real user.
+    else if (userInfo.email == "" && userInfo.id == "" && req.headers['x-adsk-signature'] == hash) {
         updateGDPRTask(req, res);
         res.status(200).send("Task updated");
     }
     else {
+        console.log("NOT CALLED FROM AUTHORIZED SERVICE")
         res.status(403).send("Not called from webhook service");
     }
 }

--- a/lib/gdpr.js
+++ b/lib/gdpr.js
@@ -208,7 +208,6 @@ exports.handleGDPRRRequest = function (req, res) {
         res.status(200).send("Task updated");
     }
     else {
-        console.log(hash);
         console.log("sending 403 - invalid hash ");
         res.status(403).send("Not called from webhook service, invalid hash");
     }

--- a/lib/users.js
+++ b/lib/users.js
@@ -20,7 +20,7 @@ exports.initDebugUser = function(name,email,oxygenId,cb) {
 	  if (err || !user) {
 
 	    console.log('Attempting to create new debug user...');
-	    var master_user = new UserModel({username: name, oxygen_id:oxygenId,email:email, super_user: true});
+	    var master_user = new UserModel({username: name, oxygen_id: oxygenId, email: email, super_user: true});
 
 	    master_user.save(function(err) {
 	    	if (err) {

--- a/lib/users.js
+++ b/lib/users.js
@@ -27,7 +27,9 @@ exports.initDebugUser = function(name,email,oxygenId,cb) {
 	    		console.log('Failed to create new debug user...')
 	    	}
 			console.log('Successfully created new debug user...')
-			cb(err);
+			if(cb){
+				cb(err);
+			}
 	    });
 	  }
       

--- a/lib/users.js
+++ b/lib/users.js
@@ -6,28 +6,28 @@ var UserModel = require('../models/user').UserModel
 
 /**
  * Create new dummy user for debugging.  THIS IS NOT PRODUCTION CODE.
- *
- * @param {Object} The parsed and validated json from the client.
+ * @param {*} username of the user
+ * @param {*} email of the user
+ * @param {*} oxygen_id of the user
  * @param {Function} Callback to execute after inserting. The argument is an error object.
  * @api private
  */
 
-var debugUserName = 'test';
+exports.initDebugUser = function(name,email,oxygenId,cb) {
 
-exports.initDebugUser = function() {
-
-	UserModel.findOne({username: debugUserName}, function(err, user){
+	UserModel.findOne({username: name}, function(err, user){
 
 	  if (err || !user) {
 
 	    console.log('Attempting to create new debug user...');
-	    var master_user = new UserModel({username: debugUserName, super_user: true});
+	    var master_user = new UserModel({username: name, oxygen_id:oxygenId,email:email, super_user: true});
 
 	    master_user.save(function(err) {
 	    	if (err) {
 	    		console.log('Failed to create new debug user...')
 	    	}
-	    	console.log('Successfully created new debug user...')
+			console.log('Successfully created new debug user...')
+			cb(err);
 	    });
 	  }
       
@@ -35,8 +35,8 @@ exports.initDebugUser = function() {
 
 }
 
-exports.cleanupDebugUser = function(){
-    UserModel.findOneAndRemove({username: debugUserName}, function(err, user){
+exports.cleanupDebugUser = function(name){
+    UserModel.findOneAndRemove({username: name}, function(err, user){
         if(err || !user){
             console.log("Could not find the test user for deletion.");
         }

--- a/test/gdprHandlerTests.js
+++ b/test/gdprHandlerTests.js
@@ -41,7 +41,7 @@ function getRandId() {
  * @param {*} authDetails endpoint and auth details for a product
  */
 function constructMockWebhookPayload(task, authDetails) {
-    var date = new Date();
+    var date = "aStableDate";
     var payload = {
         'version': 1,
         'hook': {
@@ -100,6 +100,8 @@ describe('POST /gdprDeleteRequest', function () {
         var task = generateRandomTask();
         task.user_email = "ЕЀЁName@gmail.com";
         task.user_name = "ЕЀЁName";
+        task.user_o2_id = "aStableID";
+        task.number = "aStableID"
 
         var name = task.user_name;
         var email = task.user_email;
@@ -112,7 +114,7 @@ describe('POST /gdprDeleteRequest', function () {
             client_id: "a client id",
             callback_url: "updateTaskURL"
         };
-        var signature = "INCORRECT_SIGNATURE";
+        var signature = "sha1hash=90ec17a14d60deb97e0c1323133a7d5cfb0da03d";
         var testWebhookPayload = constructMockWebhookPayload(task, authDetails);
 
         request

--- a/test/gdprHandlerTests.js
+++ b/test/gdprHandlerTests.js
@@ -9,8 +9,22 @@ var request = require('supertest')
     , sinon = require("sinon")
     , gdprHandler = require('../lib/gdpr.js')
     , crypto = require('crypto')
-    , assert = require('assert');
+    , assert = require('assert')
+    , secrets = require("../lib/secrets.js");
 
+
+
+function generateHash(data) {
+    const secret = secrets.forge.gdpr_id;
+    //check whether the hash matches. Ignore the request if 
+    //has does not match.
+    const hash = 'sha1hash=' +
+        crypto.createHmac('sha1', secret)
+            //pass utf-8 explicitly as the default encoding changed in node >6.x
+            .update(JSON.stringify(data), 'utf8')
+            .digest('hex');
+    return hash;
+}
 
 function generateRandomTask(status) {
     return {
@@ -121,33 +135,206 @@ describe('POST /gdprDeleteRequest', function () {
             .post('/gdprDeleteRequest')
             .set('x-adsk-signature', signature)
             .send(testWebhookPayload)
+            .expect("GDPR Package Manager : Delete request for the task " + task.number)
             .expect(200, done);
 
     });
 
-    it('should respond with 200 and open task if user has email and oxygen id and is found', function () {
+    it('should respond with 200 and open task if user has email and oxygen id and is found', function (done) {
 
+        var task = generateRandomTask();
+        task.user_email = "aValidEmail@gmail.com";
+        task.user_name = "aValidName";
+        task.user_o2_id = "ao2StableID";
+        task.number = "aStableID"
+
+        var name = task.user_name;
+        var email = task.user_email;
+        var id = task.user_o2_id;
+        //generate test user.
+        user.initDebugUser(name, email, id);
+
+        var authDetails = {
+            webhook_endpoint: "gdprDeleteRequestHandler",
+            client_id: "a client id",
+            callback_url: "updateTaskURL"
+        };
+        var testWebhookPayload = constructMockWebhookPayload(task, authDetails);
+        var signature = generateHash(testWebhookPayload);
+
+        request
+            .post('/gdprDeleteRequest')
+            .set('x-adsk-signature', signature)
+            .send(testWebhookPayload)
+            .expect("GDPR Package Manager : Delete request for the task " + task.number)
+            .expect(200, done);
 
     });
 
-    it('should close task if user is not in database', function () {
+    it('should close task if user is not in database', function (done) {
 
+        var task = generateRandomTask();
+        task.user_email = "aValidEmail@gmail.com";
+        task.user_name = "aValidName";
+        task.user_o2_id = "ao2StableID";
+        task.number = "aStableID"
+
+        var name = task.user_name;
+        var email = task.user_email;
+        var id = task.user_o2_id;
+        //make sure test user is gone.
+        user.cleanupDebugUser(name);
+
+        var authDetails = {
+            webhook_endpoint: "gdprDeleteRequestHandler",
+            client_id: "a client id",
+            callback_url: "updateTaskURL"
+        };
+        var testWebhookPayload = constructMockWebhookPayload(task, authDetails);
+        var signature = generateHash(testWebhookPayload);
+
+        request
+            .post('/gdprDeleteRequest')
+            .set('x-adsk-signature', signature)
+            .send(testWebhookPayload)
+            .expect("Task updated")
+            .expect(200, done);
 
     });
 
-    it('should close task if user is not in database even if they have empty email', function () {
+    it(`should close task if user is not in database even
+     if they have empty email and db contains another user with empty email`, function (done) {
 
+            var task = generateRandomTask();
+            task.user_email = "";
+            task.user_name = "aValidName";
+            task.user_o2_id = "ao2StableID";
+            task.number = "aStableID"
+
+            var name = task.user_name;
+            var email = task.user_email;
+            var id = task.user_o2_id;
+
+            //make sure test user is gone.
+            user.cleanupDebugUser(name);
+            user.initDebugUser("anotherUser", "", "anotherUserId");
+
+
+            var authDetails = {
+                webhook_endpoint: "gdprDeleteRequestHandler",
+                client_id: "a client id",
+                callback_url: "updateTaskURL"
+            };
+            var testWebhookPayload = constructMockWebhookPayload(task, authDetails);
+            var signature = generateHash(testWebhookPayload);
+
+            request
+                .post('/gdprDeleteRequest')
+                .set('x-adsk-signature', signature)
+                .send(testWebhookPayload)
+                .expect("Task updated")
+                .expect(200, done);
+
+        });
+
+    it(`should close task if user is not in database even
+    if they have empty o2-id and db contains another user with empty o2-id`, function (done) {
+
+            var task = generateRandomTask();
+            task.user_email = "aValidEmail@gmailcom";
+            task.user_name = "aValidName";
+            task.user_o2_id = "";
+            task.number = "aStableID"
+
+            var name = task.user_name;
+            var email = task.user_email;
+            var id = task.user_o2_id;
+
+            //make sure test user is gone.
+            user.cleanupDebugUser(name);
+            user.initDebugUser("anotherUser", "anotherEmail", "");
+
+
+            var authDetails = {
+                webhook_endpoint: "gdprDeleteRequestHandler",
+                client_id: "a client id",
+                callback_url: "updateTaskURL"
+            };
+            var testWebhookPayload = constructMockWebhookPayload(task, authDetails);
+            var signature = generateHash(testWebhookPayload);
+
+            request
+                .post('/gdprDeleteRequest')
+                .set('x-adsk-signature', signature)
+                .send(testWebhookPayload)
+                .expect("Task updated")
+                .expect(200, done);
+        });
+
+
+    it('should respond with 200 and close task if user has empty email and o2-id', function (done) {
+
+        var task = generateRandomTask();
+        task.user_email = "";
+        task.user_name = "aValidName";
+        task.user_o2_id = "";
+        task.number = "aStableID"
+
+        var name = task.user_name;
+        var email = task.user_email;
+        var id = task.user_o2_id;
+
+        //make sure test user is gone.
+        user.cleanupDebugUser(name);
+
+        var authDetails = {
+            webhook_endpoint: "gdprDeleteRequestHandler",
+            client_id: "a client id",
+            callback_url: "updateTaskURL"
+        };
+        var testWebhookPayload = constructMockWebhookPayload(task, authDetails);
+        var signature = generateHash(testWebhookPayload);
+
+        request
+            .post('/gdprDeleteRequest')
+            .set('x-adsk-signature', signature)
+            .send(testWebhookPayload)
+            .expect("Task updated")
+            .expect(200, done);
 
     });
 
-    it('should close task if user is not in database even if they have empty o2-id', function () {
+    it('should respond with 200 and close task if user has empty email and o2-id and another user is in db with empty data', function (done) {
+
+        var task = generateRandomTask();
+        task.user_email = "";
+        task.user_name = "aValidName";
+        task.user_o2_id = "";
+        task.number = "aStableID"
+
+        var name = task.user_name;
+        var email = task.user_email;
+        var id = task.user_o2_id;
+
+        //make sure test user is gone.
+        user.cleanupDebugUser(name);
+        user.initDebugUser("anotherUser", "", "");
 
 
-    });
+        var authDetails = {
+            webhook_endpoint: "gdprDeleteRequestHandler",
+            client_id: "a client id",
+            callback_url: "updateTaskURL"
+        };
+        var testWebhookPayload = constructMockWebhookPayload(task, authDetails);
+        var signature = generateHash(testWebhookPayload);
 
-
-    it('should respond with 200 and open task if user has email and oxygen id', function () {
-
+        request
+            .post('/gdprDeleteRequest')
+            .set('x-adsk-signature', signature)
+            .send(testWebhookPayload)
+            .expect("Task updated")
+            .expect(200, done);
 
     });
 

--- a/test/gdprHandlerTests.js
+++ b/test/gdprHandlerTests.js
@@ -1,0 +1,152 @@
+
+process.env.NODE_ENV = 'test';
+
+var request = require('supertest')
+    , app = require('../app.js')
+    , mocha = require('mocha')
+    , request = request(app)
+    , user = require('../lib/users.js')
+    , sinon = require("sinon")
+    , gdprHandler = require('../lib/gdpr.js')
+    , crypto = require('crypto')
+    , assert = require('assert');
+
+
+function generateRandomTask(status) {
+    return {
+        "status": status,
+        "description": "",
+        "number": "aTaskId" + getRandId(),
+        "user_type": "individual",
+        "request_type": "gdpr.delete",
+        "request_number": "aRequestNumber",
+        "client_id": "aClientID",
+        "created_date": "2018-07-27 18:15:12",
+        "notify_date": "2018-07-27 18:15:14",
+        "user_o2_id": "AnOxygenID" + getRandId(),
+        "user_name": "auser" + getRandId(),
+        "user_email": "auser" + getRandId() + "@gmail.com",
+        "app_name": "Some Application"
+    }
+}
+
+function getRandId() {
+    const id = crypto.randomBytes(16).toString("hex");
+    return id;
+}
+
+/**
+ * Constructor of webhook endpoint test task payload.
+ * @param {*} task a task object
+ * @param {*} authDetails endpoint and auth details for a product
+ */
+function constructMockWebhookPayload(task, authDetails) {
+    var date = new Date();
+    var payload = {
+        'version': 1,
+        'hook': {
+            'eventType': task['request_type'],
+            'hookId': 'GDPR Notification System',
+            'clientID': authDetails.client_id,
+            'webhookEndpoint': authDetails.webhook_endpoint,
+            'createdDate': date,
+        },
+        'payload': {
+            'version': 1,
+            'taskId': task['number'],
+            'user_info': {
+                'id': task['user_o2_id'],
+                'email': task['user_email'],
+                'name': task['user_name']
+            },
+            'callbackUrl': authDetails.callback_url,
+            'respondBy': date,
+            'status': task['status']
+        }
+    };
+    return payload
+}
+
+describe('POST /gdprDeleteRequest', function () {
+
+
+    it('should respond with 403 for inconsistent hash signature', function (done) {
+        var task = generateRandomTask();
+
+        var name = task.user_name;
+        var email = task.user_email;
+        var id = task.user_o2_id;
+        //generate test user.
+        user.initDebugUser(name, email, id);
+
+        var authDetails = {
+            webhook_endpoint: "gdprDeleteRequestHandler",
+            client_id: "a client id",
+            callback_url: "updateTaskURL"
+        };
+        var signature = "INCORRECT_SIGNATURE";
+        var testWebhookPayload = constructMockWebhookPayload(task, authDetails);
+
+        request
+            .post('/gdprDeleteRequest')
+            .set('x-adsk-signature', signature)
+            .send(testWebhookPayload)
+            .expect(403, done);
+
+    });
+
+    it('should not return 403 if user_email or name includes non ASCII characters', function (done) {
+
+        var task = generateRandomTask();
+        task.user_email = "ЕЀЁName@gmail.com";
+        task.user_name = "ЕЀЁName";
+
+        var name = task.user_name;
+        var email = task.user_email;
+        var id = task.user_o2_id;
+        //generate test user.
+        user.initDebugUser(name, email, id);
+
+        var authDetails = {
+            webhook_endpoint: "gdprDeleteRequestHandler",
+            client_id: "a client id",
+            callback_url: "updateTaskURL"
+        };
+        var signature = "INCORRECT_SIGNATURE";
+        var testWebhookPayload = constructMockWebhookPayload(task, authDetails);
+
+        request
+            .post('/gdprDeleteRequest')
+            .set('x-adsk-signature', signature)
+            .send(testWebhookPayload)
+            .expect(200, done);
+
+    });
+
+    it('should respond with 200 and open task if user has email and oxygen id and is found', function () {
+
+
+    });
+
+    it('should close task if user is not in database', function () {
+
+
+    });
+
+    it('should close task if user is not in database even if they have empty email', function () {
+
+
+    });
+
+    it('should close task if user is not in database even if they have empty o2-id', function () {
+
+
+    });
+
+
+    it('should respond with 200 and open task if user has email and oxygen id', function () {
+
+
+    });
+
+});

--- a/test/packageRoutes.js
+++ b/test/packageRoutes.js
@@ -46,7 +46,7 @@ var ds_pkg_datas = [];
 describe('Package route tests.', function(){
     
     before(function(done){
-        user.initDebugUser();
+        user.initDebugUser("test","testemail","testId");
         done();
     })
     


### PR DESCRIPTION
This PR addresses some issues we found in the GDPR handler in PM.

* When the user had a valid email, but `""` empty.string as their o2-id  (or vice versa) - the user would be found in the database (matching some other user with empty user data), and this would result in a false positive task being opened.

* A test mode is added to the gdpr methods to suppress actual slack messages or requests from being made when testing.

*  Tests are added for gdpr handler

* `initDebugUser` method has parameters added and a callback which was initially documented but looked like it was removed by mistake at some point. (not sure on this)

PTAL @alfarok @ramramps 
FYI @Dewb 
